### PR TITLE
fixed installation issues on MacOS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 *.sw?
 tags
 *.so
+*.o
 *egg-info
-sql/multicorn--0.0.2.sql
+sql/multicorn--*.sql
 *.pyc
 /build
 /dist

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,18 @@
+import popen2
 from setuptools import setup, find_packages, Extension
 
+# hum... borrowed from psycopg2
+def get_pg_config(kind, pg_config="pg_config"):
+    p = popen2.popen3(pg_config + " --" + kind)
+    r = p[0].readline().strip()
+    if not r:
+        raise Warning(p[2].readline())
+    return r
+
+include_dirs = [get_pg_config(d) for d in ("includedir", "pkgincludedir", "includedir-server")]
+
 multicorn_utils_module = Extension('multicorn._utils',
-        include_dirs=['/usr/include/postgresql/', '/usr/include/postgresql/server', '/usr/include/postgresql/internal/', '/usr/pgsql-9.2/include/server'],
+        include_dirs=include_dirs,
         extra_compile_args = ['-shared'],
         sources=['src/utils.c'])
 


### PR DESCRIPTION
1. BSD sed on MacOS X interprets "-i" as a file if placed at the end, hence the "sed: -i: No such file or directory" errors.
2. When using MacPorts and the Python/PostgreSQL ports, the correct includes to be used are in /opt/local/include. Using pythonX.Y-config and pg_config instead of hardcoded directories resolves that.

Beware that I reused a get_pg_config function from psycopg2 but haven't checked licence compatibility.
## 

fixed sed -i issues on OSX (bug #1154)
fixed hardcoded /usr/include/{postgresql,python} directories in Makefile and setup.py
adjusted .gitignore
