### PR TITLE
Added support for savepoints.

### DIFF
--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -165,6 +165,18 @@ class ForeignDataWrapper(object):
     def end_modify(self):
         pass
 
+    def begin(self, serializable):
+        pass
+
+    def sub_begin(self, level):
+        pass
+
+    def sub_rollback(self, level):
+        pass
+
+    def sub_commit(self, level):
+        pass
+
 
 class TransactionAwareForeignDataWrapper(ForeignDataWrapper):
 

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -93,6 +93,9 @@ static void multicornEndForeignModify(EState *estate, ResultRelInfo *resultRelIn
 
 static void multicorn_xact_callback(XactEvent event, void *arg);
 
+static void multicorn_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
+                                           SubTransactionId parentSubid, void *arg);
+
 typedef struct MulticornCallbackData
 {
 	Oid			foreigntableid;
@@ -111,6 +114,7 @@ _PG_init()
 	Py_Initialize();
 	multicorn_modified_relations = NULL;
 	RegisterXactCallback(multicorn_xact_callback, NULL);
+        RegisterSubXactCallback(multicorn_subxact_callback, NULL);
 }
 
 void
@@ -539,7 +543,7 @@ multicornBeginForeignModify(ModifyTableState *mtstate,
 	modstate->rowidAttrName = getRowIdColumn(modstate->fdw_instance);
 	initConversioninfo(modstate->cinfos, TupleDescGetAttInMetadata(desc));
 	oldcontext = MemoryContextSwitchTo(TopMemoryContext);
-	multicorn_modified_relations = lappend_oid(multicorn_modified_relations, rel->rd_id);
+	multicorn_modified_relations = list_append_unique_oid(multicorn_modified_relations, rel->rd_id);
 	MemoryContextSwitchTo(oldcontext);
 	if (ps->ps_ResultTupleSlot)
 	{
@@ -690,33 +694,75 @@ multicorn_xact_callback(XactEvent event, void *arg)
 	foreach(lc, multicorn_modified_relations)
 	{
 		Oid			foreigntableid = lfirst_oid(lc);
+                CacheEntry* entry  = getCacheEntry(foreigntableid);
+                instance = entry->value;
+
+                if (entry->xact_depth == 0)
+                        continue;
 
 		switch (event)
 		{
 			case XACT_EVENT_PRE_COMMIT:
-				instance = getInstance(foreigntableid);
 				PyObject_CallMethod(instance, "pre_commit", "()");
 				errorCheck();
-				Py_DECREF(instance);
 				break;
 			case XACT_EVENT_COMMIT:
-				instance = getInstance(foreigntableid);
 				PyObject_CallMethod(instance, "commit", "()");
 				errorCheck();
-				Py_DECREF(instance);
 				break;
 			case XACT_EVENT_ABORT:
-				instance = getInstance(foreigntableid);
 				PyObject_CallMethod(instance, "rollback", "()");
 				errorCheck();
-				Py_DECREF(instance);
 				break;
 			default:
 				break;
 		}
+                Py_DECREF(instance);
+
+                entry->xact_depth = 0;
 	}
 	list_free(multicorn_modified_relations);
 	multicorn_modified_relations = NULL;
+}
+
+
+/*
+ * Callback used to propagate a subtransaction end.
+ */
+static void
+multicorn_subxact_callback(SubXactEvent event, SubTransactionId mySubid,
+                                           SubTransactionId parentSubid, void *arg)
+{
+  PyObject      *instance;
+  int           curlevel;
+  ListCell      *lc;
+
+
+  /* Nothing to do after commit or subtransaction start. */
+  if (event == SUBXACT_EVENT_COMMIT_SUB || event == SUBXACT_EVENT_START_SUB)
+    return;
+
+  curlevel = GetCurrentTransactionNestLevel();
+
+  foreach(lc, multicorn_modified_relations)
+  {
+    Oid foreigntableid = lfirst_oid(lc);
+    CacheEntry* entry  = getCacheEntry(foreigntableid);
+    instance = entry->value;
+
+    if (event == SUBXACT_EVENT_PRE_COMMIT_SUB)
+    {
+      PyObject_CallMethod(instance, "sub_commit", "(i)", curlevel);
+    }
+    else
+    {
+      PyObject_CallMethod(instance, "sub_rollback", "(i)", curlevel);
+    }
+    errorCheck();
+    Py_DECREF(instance);
+
+    entry->xact_depth--;
+  }
 }
 #endif
 

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -22,6 +22,18 @@
 
 /* Data structures */
 
+typedef struct CacheEntry
+{
+        Oid                     hashkey;
+        PyObject   *value;
+        List       *options;
+        List       *columns;
+        int        xact_depth;
+        /* Keep the "options" and "columns" in a specific context to avoid leaks. */
+        MemoryContext cacheContext;
+}       CacheEntry;
+
+
 typedef struct ConversionInfo
 {
 	char	   *attrname;
@@ -129,6 +141,9 @@ void getRelSize(MulticornPlanState * state,
 		   int *width);
 
 List	   *pathKeys(MulticornPlanState * state);
+
+CacheEntry * getCacheEntry(Oid foreigntableid);
+
 
 
 /* query.c */


### PR DESCRIPTION
Hi,

This patch handles savepoints in a similar manner to how the postgres_fdw extension ([connection.c](https://github.com/postgres/postgres/blob/fc9f4e9f8c981bbc050e5566cf558112c938da2c/contrib/postgres_fdw/connection.c)) behaves, keeping track of the current depth of transactions and forwarding that information to the python instance.
