### PR TITLE
Add schema option and use when creating sqlalchemy Table instance

### DIFF
--- a/python/multicorn/sqlalchemyfdw.py
+++ b/python/multicorn/sqlalchemyfdw.py
@@ -48,6 +48,7 @@ class SqlAlchemyFdw(ForeignDataWrapper):
     Accepted options:
 
     db_url      --  the sqlalchemy connection string.
+    schema      --  (optional) schema name to qualify table name with
     tablename   --  the table name in the remote database.
 
     """
@@ -60,8 +61,9 @@ class SqlAlchemyFdw(ForeignDataWrapper):
             log_to_postgres('The tablename parameter is required', ERROR)
         self.engine = create_engine(fdw_options.get('db_url'))
         self.metadata = MetaData()
+        schema = fdw_options['schema'] if 'schema' in fdw_options else None
         tablename = fdw_options['tablename']
-        self.table = Table(tablename, self.metadata,
+        self.table = Table(tablename, self.metadata, schema = schema,
                            *[Column(col.column_name, ischema_names[col.type_name])
                              for col in fdw_columns.values()])
 


### PR DESCRIPTION
Needed a 'schema' option when configuring a foreign table when the remote database(Postgres) organized its tables into schemas. If tables are not qualified with the schema name they cannot be accessed if they are under a schema and it did not appear possible to specify a default schema via the db_url. Hopefully this or a similar schema option can be added.
