### PR TITLE
Fix import line for sqlalchemy 0.8

### DIFF
--- a/python/multicorn/sqlalchemyfdw.py
+++ b/python/multicorn/sqlalchemyfdw.py
@@ -4,7 +4,7 @@ from . import ForeignDataWrapper
 from .utils import log_to_postgres, ERROR, WARNING, DEBUG
 from sqlalchemy import create_engine
 from sqlalchemy.sql import select, operators as sqlops, and_
-from sqlalchemy.sql import sqltypes
+from sqlalchemy import types as sqltypes
 from sqlalchemy.schema import Table, Column, MetaData
 from sqlalchemy.dialects.postgresql.base import ARRAY, ischema_names
 import re


### PR DESCRIPTION
There's surely a way to support both pre and post 0.8 version but I dunno how to do that out of the box
