### PR TITLE
Fix EXPLAIN tests for 9.4

### DIFF
--- a/test-2.7/expected/multicorn_planner_test.out
+++ b/test-2.7/expected/multicorn_planner_test.out
@@ -12,32 +12,32 @@ CREATE foreign table testmulticorn (
 ) server multicorn_srv options (
     option1 'option1'
 );
-explain select * from testmulticorn;
+explain (costs off) select * from testmulticorn;
 NOTICE:  [('option1', 'option1'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=10.00..400.00 rows=20 width=20)
+          QUERY PLAN           
+-------------------------------
+ Foreign Scan on testmulticorn
 (1 row)
 
-explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Nested Loop  (cost=20.00..806.05 rows=2 width=128)
+explain (costs off) select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop
    Join Filter: ((m1.test1)::text = (m2.test1)::text)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..400.00 rows=20 width=20)
-   ->  Materialize  (cost=10.00..400.10 rows=20 width=20)
-         ->  Foreign Scan on testmulticorn m2  (cost=10.00..400.00 rows=20 width=20)
+   ->  Foreign Scan on testmulticorn m1
+   ->  Materialize
+         ->  Foreign Scan on testmulticorn m2
 (5 rows)
 
-explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Nested Loop Left Join  (cost=20.00..806.05 rows=20 width=128)
+explain (costs off) select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop Left Join
    Join Filter: ((m1.test1)::text = (m2.test1)::text)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..400.00 rows=20 width=20)
-   ->  Materialize  (cost=10.00..400.10 rows=20 width=20)
-         ->  Foreign Scan on testmulticorn m2  (cost=10.00..400.00 rows=20 width=20)
+   ->  Foreign Scan on testmulticorn m1
+   ->  Materialize
+         ->  Foreign Scan on testmulticorn m2
 (5 rows)
 
 DROP foreign table testmulticorn;
@@ -50,29 +50,29 @@ CREATE foreign table testmulticorn (
     option1 'option1',
     test_type 'planner'
 );
-explain select * from testmulticorn;
+explain (costs off) select * from testmulticorn;
 NOTICE:  [('option1', 'option1'), ('test_type', 'planner'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=10.00..200000000.00 rows=10000000 width=20)
+          QUERY PLAN           
+-------------------------------
+ Foreign Scan on testmulticorn
 (1 row)
 
-explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Nested Loop  (cost=20.00..400100000.00 rows=500000000000 width=128)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
-   ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
+explain (costs off) select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Nested Loop
+   ->  Foreign Scan on testmulticorn m1
+   ->  Foreign Scan on testmulticorn m2
          Filter: ((m1.test1)::text = (test1)::text)
 (4 rows)
 
-explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Nested Loop Left Join  (cost=20.00..400100000.00 rows=500000000000 width=128)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
-   ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
+explain (costs off) select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Nested Loop Left Join
+   ->  Foreign Scan on testmulticorn m1
+   ->  Foreign Scan on testmulticorn m2
          Filter: ((m1.test1)::text = (test1)::text)
 (4 rows)
 

--- a/test-2.7/expected/write_filesystem.out
+++ b/test-2.7/expected/write_filesystem.out
@@ -69,31 +69,31 @@ SELECT * from testmulticorn ORDER BY filename;
 (8 rows)
 
 -- Test the cost analysis
-EXPLAIN select color, size from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..120.00 rows=1 width=120)
+ Foreign Scan on testmulticorn
    Filter: (((color)::text = 'blue'::text) AND ((size)::text = 'big'::text) AND ((name)::text = 'square'::text) AND ((ext)::text = 'txt'::text))
 (2 rows)
 
-EXPLAIN select color, size from testmulticorn where color = 'blue' and size = 'big';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue' and size = 'big';
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..6000.00 rows=100 width=60)
+ Foreign Scan on testmulticorn
    Filter: (((color)::text = 'blue'::text) AND ((size)::text = 'big'::text))
 (2 rows)
 
-EXPLAIN select color, size from testmulticorn where color = 'blue';
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..600000.00 rows=10000 width=60)
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue';
+                QUERY PLAN                
+------------------------------------------
+ Foreign Scan on testmulticorn
    Filter: ((color)::text = 'blue'::text)
 (2 rows)
 
-EXPLAIN select color, size, data from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
+EXPLAIN (costs off) select color, size, data from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..1000150.00 rows=1 width=1000150)
+ Foreign Scan on testmulticorn
    Filter: (((color)::text = 'blue'::text) AND ((size)::text = 'big'::text) AND ((name)::text = 'square'::text) AND ((ext)::text = 'txt'::text))
 (2 rows)
 

--- a/test-2.7/sql/multicorn_planner_test.sql
+++ b/test-2.7/sql/multicorn_planner_test.sql
@@ -14,11 +14,11 @@ CREATE foreign table testmulticorn (
     option1 'option1'
 );
 
-explain select * from testmulticorn;
+explain (costs off) select * from testmulticorn;
 
-explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+explain (costs off) select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
 
-explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+explain (costs off) select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
 
 DROP foreign table testmulticorn;
 
@@ -32,11 +32,11 @@ CREATE foreign table testmulticorn (
     test_type 'planner'
 );
 
-explain select * from testmulticorn;
+explain (costs off) select * from testmulticorn;
 
-explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+explain (costs off) select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
 
-explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+explain (costs off) select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
 
 
 DROP EXTENSION multicorn cascade;

--- a/test-3.3/expected/multicorn_planner_test.out
+++ b/test-3.3/expected/multicorn_planner_test.out
@@ -12,32 +12,32 @@ CREATE foreign table testmulticorn (
 ) server multicorn_srv options (
     option1 'option1'
 );
-explain select * from testmulticorn;
+explain (costs off) select * from testmulticorn;
 NOTICE:  [('option1', 'option1'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
-                              QUERY PLAN                              
-----------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=10.00..400.00 rows=20 width=20)
+          QUERY PLAN           
+-------------------------------
+ Foreign Scan on testmulticorn
 (1 row)
 
-explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Nested Loop  (cost=20.00..806.05 rows=2 width=128)
+explain (costs off) select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop
    Join Filter: ((m1.test1)::text = (m2.test1)::text)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..400.00 rows=20 width=20)
-   ->  Materialize  (cost=10.00..400.10 rows=20 width=20)
-         ->  Foreign Scan on testmulticorn m2  (cost=10.00..400.00 rows=20 width=20)
+   ->  Foreign Scan on testmulticorn m1
+   ->  Materialize
+         ->  Foreign Scan on testmulticorn m2
 (5 rows)
 
-explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
-                                     QUERY PLAN                                      
--------------------------------------------------------------------------------------
- Nested Loop Left Join  (cost=20.00..806.05 rows=20 width=128)
+explain (costs off) select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+                      QUERY PLAN                      
+------------------------------------------------------
+ Nested Loop Left Join
    Join Filter: ((m1.test1)::text = (m2.test1)::text)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..400.00 rows=20 width=20)
-   ->  Materialize  (cost=10.00..400.10 rows=20 width=20)
-         ->  Foreign Scan on testmulticorn m2  (cost=10.00..400.00 rows=20 width=20)
+   ->  Foreign Scan on testmulticorn m1
+   ->  Materialize
+         ->  Foreign Scan on testmulticorn m2
 (5 rows)
 
 DROP foreign table testmulticorn;
@@ -50,29 +50,29 @@ CREATE foreign table testmulticorn (
     option1 'option1',
     test_type 'planner'
 );
-explain select * from testmulticorn;
+explain (costs off) select * from testmulticorn;
 NOTICE:  [('option1', 'option1'), ('test_type', 'planner'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
-                                    QUERY PLAN                                    
-----------------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=10.00..200000000.00 rows=10000000 width=20)
+          QUERY PLAN           
+-------------------------------
+ Foreign Scan on testmulticorn
 (1 row)
 
-explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Nested Loop  (cost=20.00..400100000.00 rows=500000000000 width=128)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
-   ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
+explain (costs off) select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 = m2.test1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Nested Loop
+   ->  Foreign Scan on testmulticorn m1
+   ->  Foreign Scan on testmulticorn m2
          Filter: ((m1.test1)::text = (test1)::text)
 (4 rows)
 
-explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
-                                        QUERY PLAN                                         
--------------------------------------------------------------------------------------------
- Nested Loop Left Join  (cost=20.00..400100000.00 rows=500000000000 width=128)
-   ->  Foreign Scan on testmulticorn m1  (cost=10.00..200000000.00 rows=10000000 width=20)
-   ->  Foreign Scan on testmulticorn m2  (cost=10.00..20.00 rows=1 width=20)
+explain (costs off) select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
+                     QUERY PLAN                     
+----------------------------------------------------
+ Nested Loop Left Join
+   ->  Foreign Scan on testmulticorn m1
+   ->  Foreign Scan on testmulticorn m2
          Filter: ((m1.test1)::text = (test1)::text)
 (4 rows)
 

--- a/test-3.3/expected/write_filesystem.out
+++ b/test-3.3/expected/write_filesystem.out
@@ -69,31 +69,31 @@ SELECT * from testmulticorn ORDER BY filename;
 (8 rows)
 
 -- Test the cost analysis
-EXPLAIN select color, size from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..120.00 rows=1 width=120)
+ Foreign Scan on testmulticorn
    Filter: (((color)::text = 'blue'::text) AND ((size)::text = 'big'::text) AND ((name)::text = 'square'::text) AND ((ext)::text = 'txt'::text))
 (2 rows)
 
-EXPLAIN select color, size from testmulticorn where color = 'blue' and size = 'big';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue' and size = 'big';
                                  QUERY PLAN                                  
 -----------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..6000.00 rows=100 width=60)
+ Foreign Scan on testmulticorn
    Filter: (((color)::text = 'blue'::text) AND ((size)::text = 'big'::text))
 (2 rows)
 
-EXPLAIN select color, size from testmulticorn where color = 'blue';
-                                 QUERY PLAN                                 
-----------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..600000.00 rows=10000 width=60)
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue';
+                QUERY PLAN                
+------------------------------------------
+ Foreign Scan on testmulticorn
    Filter: ((color)::text = 'blue'::text)
 (2 rows)
 
-EXPLAIN select color, size, data from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
+EXPLAIN (costs off) select color, size, data from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
                                                                    QUERY PLAN                                                                    
 -------------------------------------------------------------------------------------------------------------------------------------------------
- Foreign Scan on testmulticorn  (cost=20.00..1000150.00 rows=1 width=1000150)
+ Foreign Scan on testmulticorn
    Filter: (((color)::text = 'blue'::text) AND ((size)::text = 'big'::text) AND ((name)::text = 'square'::text) AND ((ext)::text = 'txt'::text))
 (2 rows)
 

--- a/test-common/multicorn_testfilesystem.include
+++ b/test-common/multicorn_testfilesystem.include
@@ -2,10 +2,10 @@
 SELECT * from testmulticorn ORDER BY filename;
 
 -- Test the cost analysis
-EXPLAIN select color, size from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
-EXPLAIN select color, size from testmulticorn where color = 'blue' and size = 'big';
-EXPLAIN select color, size from testmulticorn where color = 'blue';
-EXPLAIN select color, size, data from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue' and size = 'big';
+EXPLAIN (costs off) select color, size from testmulticorn where color = 'blue';
+EXPLAIN (costs off) select color, size, data from testmulticorn where color = 'blue' and size = 'big' and name = 'square' and ext = 'txt';
 
 -- Test insertion
 


### PR DESCRIPTION
9.4 adds a "Planning time" line to simple "EXPLAIN" output. Fix by using
"EXPLAIN (costs off)".
