### PR TITLE
Convert buffer size from str to int in xmlfdw

### DIFF
--- a/python/multicorn/csvfdw.py
+++ b/python/multicorn/csvfdw.py
@@ -30,7 +30,7 @@ class CsvFdw(ForeignDataWrapper):
 
     def execute(self, quals, columns):
         with open(self.filename) as stream:
-            reader = csv.reader(stream, delimiter=self.delimiter)
+            reader = csv.reader(stream, delimiter=self.delimiter, quotechar=self.quotechar)
             count = 0
             checked = False
             for line in reader:

--- a/python/multicorn/xmlfdw.py
+++ b/python/multicorn/xmlfdw.py
@@ -61,7 +61,7 @@ class XMLFdw(ForeignDataWrapper):
         super(XMLFdw, self).__init__(fdw_options, fdw_columns)
         self.filename = fdw_options['filename']
         self.elem_tag = fdw_options['elem_tag']
-        self.buffer_size = fdw_options.get('buffer_size', 4096)
+        self.buffer_size = int(fdw_options.get('buffer_size', 4096))
         self.columns = fdw_columns
 
     def execute(self, quals, columns):


### PR DESCRIPTION
Hello,

When using buffer_size with XML FDW, there were an Python Type Error. This pull request fixes it.

Thanks,
