### PR TITLE
Allow link flags required on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ else
 	override CPPFLAGS := $(PG_CPPFLAGS) $(CPPFLAGS)
 endif
 
+ifeq ($(PORTNAME),darwin)
+	override LDFLAGS += -undefined dynamic_lookup
+endif
 
 PYTHON_TEST_VERSION ?= $(python_version)
 PG_TEST_VERSION ?= $(MAJORVERSION)


### PR DESCRIPTION
By default, clang (which is what's actually invoked when you call gcc) will
insist that all symbols be resolved at link time, which is not what we want
here. The bug is actually in the link flags specified in PGXS; this is just
a workaround.

Tested on OS X 10.10.1 with clang-600.0.56. Fixes #88.