### PR TITLE
Specify link flags required on OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ else
 	override CPPFLAGS := $(PG_CPPFLAGS) $(CPPFLAGS)
 endif
 
+ifeq ($(PORTNAME),darwin)
+	override LDFLAGS += -undefined dynamic_lookup -bundle_loader $(shell $(PG_CONFIG) --bindir)/postgres
+endif
 
 PYTHON_TEST_VERSION ?= $(python_version)
 PG_TEST_VERSION ?= $(MAJORVERSION)


### PR DESCRIPTION
There a couple of issues with the link flags specified in PGXS for OS X, which
this commit works around:

1. `-undefined dynamic_lookup` is needed for the linker not to require that all
   symbols be resolved at link time.
2. -bundle_loader is needed to have the symbols in the `postgres` binary take
   precedence over symbols with the same name defined elsewhere during runtime
   resolution. In particular, a function named `hash_create` is also defined in
   libsystem_c.dylib, and that function was being called without -bundle_loader
   specified.

Tested on OS X 10.10.2 with clang-600.0.56. Fixes #88. Fixes #90.