### PR TITLE
Add RPM target to makefile to enable building multicorn as an RPM

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include src/multicorn.h
 include multicorn.control
 include sql/multicorn--1.1.1.sql
+include doc/multicorn.md
+include src/*
+include Makefile
+include preflight-check.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include src/multicorn.h
+include multicorn.control
+include sql/multicorn--1.1.1.sql

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,10 @@ python_code: setup.py
 rpm: setup.py
 	@echo "About to make RPM"
 	cp $(srcdir)/setup.py ./setup--$(EXTVERSION).py
+	cp $(srcdir)/sql/multicorn.sql ./sql/multicorn--$(EXTVERSION).sql
 	sed -i -e "s/__VERSION__/$(EXTVERSION)-dev/g" ./setup--$(EXTVERSION).py
 	$(PYTHON) ./setup--$(EXTVERSION).py bdist --format=rpm
-	rm ./setup--$(EXTVERSION).py
+	rm ./setup--$(EXTVERSION).py ./sql/multicorn--$(EXTVERSION).sql
 
 
 release-zip: all

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ python_code: setup.py
 	$(PYTHON) ./setup--$(EXTVERSION).py install
 	rm ./setup--$(EXTVERSION).py
 
+rpm: setup.py
+	@echo "About to make RPM"
+	cp $(srcdir)/setup.py ./setup--$(EXTVERSION).py
+	sed -i -e "s/__VERSION__/$(EXTVERSION)-dev/g" ./setup--$(EXTVERSION).py
+	$(PYTHON) ./setup--$(EXTVERSION).py bdist --format=rpm
+	rm ./setup--$(EXTVERSION).py
+
+
 release-zip: all
 	git archive --format zip --prefix=multicorn-$(EXTVERSION)/ --output ./multicorn-$(EXTVERSION).zip HEAD
 	unzip ./multicorn-$(EXTVERSION).zip

--- a/setup.py
+++ b/setup.py
@@ -35,22 +35,6 @@ class MulticornBuild(build):
       raise Warning(p[2].readline())
     # After original build
 
-class MulticornInstall(install):
-    def initialize_options(self):
-        install.initialize_options(self)
-        self.build_scripts = None
-
-    def finalize_options(self):
-        install.finalize_options(self)
-        self.set_undefined_options('build', ('build_scripts', 'build_scripts'))
-
-    def run(self):
-        # run original install code
-        install.run(self)
-
-        # install XCSoar executables
-        self.copy_tree(self.build_lib, self.install_lib)
-
 
 
 setup(
@@ -66,6 +50,5 @@ setup(
 	],
   cmdclass={
     'build':MulticornBuild,
-  #  'install':MulticornInstall,
   }
 )

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ def get_pg_config(kind, pg_config="pg_config"):
     return r
 
 include_dirs = [get_pg_config(d) for d in ("includedir", "pkgincludedir", "includedir-server")]
+include_dirs.append('src')
 
 multicorn_utils_module = Extension('multicorn._utils',
         include_dirs=include_dirs,

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ def get_pg_config(kind, pg_config="pg_config"):
     return r
 
 include_dirs = [get_pg_config(d) for d in ("includedir", "pkgincludedir", "includedir-server")]
-include_dirs.append('src')
 
 multicorn_utils_module = Extension('multicorn._utils',
         include_dirs=include_dirs,
@@ -24,5 +23,6 @@ setup(
  license='Postgresql',
  package_dir={'': 'python'},
  packages=['multicorn', 'multicorn.fsfdw'],
- ext_modules = [multicorn_utils_module]
+ ext_modules = [multicorn_utils_module],
+ data_files=[('/usr/pgsql-9.3/share/extension', ['multicorn.control', 'sql/multicorn--1.1.1.sql'])],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
 import subprocess
 from setuptools import setup, find_packages, Extension
 
+
+import os
+from sys import platform
+#from setuptools import setup
+from setuptools.command.install import install
+from distutils.command.build import build
+
+
 # hum... borrowed from psycopg2
 def get_pg_config(kind, pg_config="pg_config"):
     r = subprocess.check_output([pg_config, '--%s' % kind])
@@ -16,13 +24,48 @@ multicorn_utils_module = Extension('multicorn._utils',
         extra_compile_args = ['-shared'],
         sources=['src/utils.c'])
 
+
+class MulticornBuild(build):
+  def run(self):
+    # Original build
+    build.run(self)
+    r = subprocess.check_output(['/usr/bin/make', 'multicorn.so'])
+    r = r.strip().decode('utf8')
+    if not r:
+      raise Warning(p[2].readline())
+    # After original build
+
+class MulticornInstall(install):
+    def initialize_options(self):
+        install.initialize_options(self)
+        self.build_scripts = None
+
+    def finalize_options(self):
+        install.finalize_options(self)
+        self.set_undefined_options('build', ('build_scripts', 'build_scripts'))
+
+    def run(self):
+        # run original install code
+        install.run(self)
+
+        # install XCSoar executables
+        self.copy_tree(self.build_lib, self.install_lib)
+
+
+
 setup(
- name='multicorn',
- version='__VERSION__',
- author='Kozea',
- license='Postgresql',
- package_dir={'': 'python'},
- packages=['multicorn', 'multicorn.fsfdw'],
- ext_modules = [multicorn_utils_module],
- data_files=[('/usr/pgsql-9.3/share/extension', ['multicorn.control', 'sql/multicorn--1.1.1.sql'])],
+  name='multicorn',
+  version='__VERSION__',
+  author='Kozea',
+  license='Postgresql',
+  package_dir={'': 'python'},
+  packages=['multicorn', 'multicorn.fsfdw'],
+  ext_modules = [multicorn_utils_module],
+  data_files=[('%s/extension' % get_pg_config('sharedir'), ['multicorn.control', 'sql/multicorn--1.1.1.sql', 'doc/multicorn.md']),
+	(get_pg_config('libdir'),['multicorn.so'])
+	],
+  cmdclass={
+    'build':MulticornBuild,
+  #  'install':MulticornInstall,
+  }
 )


### PR DESCRIPTION
Have added extra elements into setup.py to build an RPM for Multicorn (including the multicorn.so).
Added a target in Makefile to make this easy to run

    make rpm

