### PR TITLE
Added compatibility with Python 2.6.0

### DIFF
--- a/META.json
+++ b/META.json
@@ -30,7 +30,7 @@
         "runtime": {
             "requires": {
                 "PostgreSQL": "9.2.0",
-                "Python": "2.7.0"
+                "Python": "2.6.0"
             }
         }
     },

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,8 @@ else
 endif
 
 ifeq ($(PORTNAME),darwin)
-	override LDFLAGS += -undefined dynamic_lookup -bundle_loader $(shell $(PG_CONFIG) --bindir)/postgres
+	override LDFLAGS += -undefined dynamic_lookup
+	# -bundle_loader $(shell $(PG_CONFIG) --bindir)/postgres
 endif
 
 PYTHON_TEST_VERSION ?= $(python_version)

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,7 +8,7 @@ Requirements
 - Postgresql 9.1+
 - Postgresql development packages
 - Python development packages
-- python 2.7 or >= python 3.3 as your default python
+- python 2.6 or >= python 3.3 as your default python
 
 If you are using *PostgreSQL 9.1*, you should use the 0.9.1 release.
 

--- a/preflight-check.sh
+++ b/preflight-check.sh
@@ -16,9 +16,9 @@ if [ ! -x "${PG_CONFIG}" ]; then
   exit 1
 fi
 
-if [ ${PY_VERSION} != "2.7" ]; then
+if [ ${PY_VERSION} != "2.7" ] && [ ${PY_VERSION} != "2.6" ]; then
   if [ ${PY27_VERSION} != "2.7" ]; then
-    echo "Found Python $PY_VERSION, but 2.7 is required."
+    echo "Found Python $PY_VERSION, but 2.6 is required."
     exit 2
   fi
 fi

--- a/python/multicorn/fsfdw/__init__.py
+++ b/python/multicorn/fsfdw/__init__.py
@@ -276,7 +276,7 @@ class FilesystemFdw(TransactionAwareForeignDataWrapper):
                                 level=ERROR,
                                 hint="You can also insert an item by providing"
                                 " only the filename and content columns")
-            values = {key: str(value) for key, value in values.items()}
+            values = dict([(key, str(value)) for key, value in values.items()])
             item_from_values = self.structured_directory.create(**values)
         elif item_from_filename is None:
             log_to_postgres("The filename, or all pattern columns are needed.",
@@ -331,9 +331,9 @@ class FilesystemFdw(TransactionAwareForeignDataWrapper):
             olditem.content = olditem.read()
         new_filename = newvalues.get(self.filename_column, oldfilename)
         filename_changed = new_filename != oldfilename
-        values = {key: (None if value is None else str(value))
+        values = dict([(key, (None if value is None else str(value)))
                   for key, value in newvalues.items()
-                  if key not in (self.filename_column, self.content_column)}
+                  if key not in (self.filename_column, self.content_column)])
         values_changed = dict(olditem) != values
         # Check for null values in the "important" parts
         null_columns = [key for key in self.structured_directory.properties

--- a/python/multicorn/processfdw.py
+++ b/python/multicorn/processfdw.py
@@ -92,5 +92,5 @@ class ProcessFdw(ForeignDataWrapper):
 
     def execute(self, quals, columns):
         for process in psutil.process_iter():
-            yield {key: self._convert(key, value)
-                   for key, value in process.as_dict(columns).items()}
+            yield dict([(key, self._convert(key, value))
+                   for key, value in process.as_dict(columns).items()])

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ from setuptools import setup, find_packages, Extension
 
 # hum... borrowed from psycopg2
 def get_pg_config(kind, pg_config="pg_config"):
-    r = subprocess.check_output([pg_config, '--%s' % kind])
-    r = r.strip().decode('utf8')
+    p = subprocess.Popen([pg_config, '--%s' % kind], stdout=subprocess.PIPE)
+    r = p.communicate()
+    r = r[0].strip().decode('utf8')
     if not r:
         raise Warning(p[2].readline())
     return r


### PR DESCRIPTION
Replacing subprocess.check_output and removing dictionary
comprehensions restored ability to build with Python 2.6 and install
Multicorn on CentOS 6 without any special steps.