### PR TITLE
Suppress messages from DROP CASCADE

### DIFF
--- a/test-2.7/expected/import_sqlalchemy.out
+++ b/test-2.7/expected/import_sqlalchemy.out
@@ -106,14 +106,7 @@ SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.o
  t2
 (2 rows)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table remote_schema.t1
-drop cascades to foreign table remote_schema.t2
 DROP SCHEMA local_schema CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to table local_schema.t1
-drop cascades to table local_schema.t2
-drop cascades to table local_schema.t3
 DROP SCHEMA remote_schema CASCADE;

--- a/test-2.7/expected/import_test.out
+++ b/test-2.7/expected/import_test.out
@@ -37,8 +37,5 @@ SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.o
  imported_table_1
 (2 rows)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table import_dest1.imported_table_2
-drop cascades to foreign table import_dest1.imported_table_1

--- a/test-2.7/expected/multicorn_alchemy_test.out
+++ b/test-2.7/expected/multicorn_alchemy_test.out
@@ -196,8 +196,6 @@ select count(*) from testalchemy;
      4
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testalchemy
 DROP table basetable;

--- a/test-2.7/expected/multicorn_cache_invalidation.out
+++ b/test-2.7/expected/multicorn_cache_invalidation.out
@@ -311,8 +311,6 @@ NOTICE:  ['test2', 'testnew']
  test2 1 0 | test1 2 0
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/multicorn_column_options_test.out
+++ b/test-2.7/expected/multicorn_column_options_test.out
@@ -55,8 +55,6 @@ NOTICE:  ['test1', 'test2']
  test1 1 0 | test2 2 0
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/multicorn_error_test.out
+++ b/test-2.7/expected/multicorn_error_test.out
@@ -20,5 +20,5 @@ ALTER server multicorn_srv options (DROP wrapper);
 ERROR:  The wrapper parameter is mandatory, specify a valid class name
 CREATE server multicorn_empty_srv foreign data wrapper multicorn;
 ERROR:  The wrapper parameter is mandatory, specify a valid class name
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to server multicorn_srv

--- a/test-2.7/expected/multicorn_logger_test.out
+++ b/test-2.7/expected/multicorn_logger_test.out
@@ -16,7 +16,5 @@ NOTICE:  [('option1', 'option1'), ('test_type', 'logger')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
 WARNING:  An error is about to occur
 ERROR:  An error occured
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/multicorn_planner_test.out
+++ b/test-2.7/expected/multicorn_planner_test.out
@@ -76,8 +76,6 @@ explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.te
          Filter: ((m1.test1)::text = (test1)::text)
 (4 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/multicorn_regression_test.out
+++ b/test-2.7/expected/multicorn_regression_test.out
@@ -469,9 +469,6 @@ NOTICE:  ['test1', 'test2', 'test3']
 SELECT * from testmulticorn where test1 = '12 €';
 ERROR:  Error in python: UnicodeDecodeError
 DETAIL:  'ascii' codec can't decode byte 0xe2 in position 3: ordinal not in range(128)
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
-drop cascades to foreign table testmulticorn2

--- a/test-2.7/expected/multicorn_sequence_test.out
+++ b/test-2.7/expected/multicorn_sequence_test.out
@@ -330,9 +330,6 @@ NOTICE:  ['test1', 'test2']
  test1 3 19 | test2 1 19
 (40 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
-drop cascades to foreign table testmulticorn2

--- a/test-2.7/expected/multicorn_test_date.out
+++ b/test-2.7/expected/multicorn_test_date.out
@@ -75,8 +75,6 @@ NOTICE:  ['test1', 'test2']
  05-03-2011 | Sun May 01 14:30:25 2011
 (10 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/multicorn_test_dict.out
+++ b/test-2.7/expected/multicorn_test_dict.out
@@ -69,8 +69,6 @@ NOTICE:  ['test1']
  3
 (20 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/multicorn_test_list.out
+++ b/test-2.7/expected/multicorn_test_list.out
@@ -129,8 +129,6 @@ NOTICE:  ['test1']
      26
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/write_filesystem.out
+++ b/test-2.7/expected/write_filesystem.out
@@ -591,11 +591,9 @@ select cleanup_dir();
  
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP FUNCTION cleanup_dir();
 DROP TABLE temp_dir;
 DROP FUNCTION create_table();
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
 DROP LANGUAGE plpythonu;

--- a/test-2.7/expected/write_savepoints.out
+++ b/test-2.7/expected/write_savepoints.out
@@ -142,8 +142,6 @@ RELEASE A;
 DROP foreign table testmulticorn_write;
 ROLLBACK;
 -- Clean up
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-2.7/expected/write_sqlalchemy.out
+++ b/test-2.7/expected/write_sqlalchemy.out
@@ -75,8 +75,6 @@ SELECT * from basetable;
 ----+-------+------------+----------+----------
 (0 rows)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testalchemy
 DROP TABLE basetable;

--- a/test-2.7/expected/write_test.out
+++ b/test-2.7/expected/write_test.out
@@ -182,9 +182,6 @@ delete from testmulticorn_write;
 NOTICE:  [('option1', 'option1'), ('row_id_column', 'teststuff'), ('test_type', 'date'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'date'), ('test2', 'timestamp without time zone')]
 ERROR:  The rowid attribute does not exist
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
-drop cascades to foreign table testmulticorn_write

--- a/test-2.7/sql/import_sqlalchemy.sql
+++ b/test-2.7/sql/import_sqlalchemy.sql
@@ -53,6 +53,7 @@ IMPORT FOREIGN SCHEMA local_schema LIMIT TO (t1) FROM SERVER multicorn_srv INTO 
 SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'remote_schema';
 IMPORT FOREIGN SCHEMA local_schema EXCEPT (t1, t3) FROM SERVER multicorn_srv INTO remote_schema ;
 SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'remote_schema';
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn CASCADE;
 DROP SCHEMA local_schema CASCADE;
 DROP SCHEMA remote_schema CASCADE;

--- a/test-2.7/sql/import_test.sql
+++ b/test-2.7/sql/import_test.sql
@@ -12,4 +12,6 @@ IMPORT FOREIGN SCHEMA import_source EXCEPT (imported_table_1, imported_table_3) 
 SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'import_dest1';
 IMPORT FOREIGN SCHEMA import_source LIMIT TO (imported_table_1) FROM SERVER multicorn_srv INTO import_dest1;
 SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.oid WHERE n.nspname = 'import_dest1';
+
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_alchemy_test.sql
+++ b/test-2.7/sql/multicorn_alchemy_test.sql
@@ -80,5 +80,6 @@ select * from testalchemy order by avarchar nulls last;
 
 select count(*) from testalchemy;
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
 DROP table basetable;

--- a/test-2.7/sql/multicorn_cache_invalidation.sql
+++ b/test-2.7/sql/multicorn_cache_invalidation.sql
@@ -59,5 +59,6 @@ ALTER foreign table testmulticorn rename test1 to testnew;
 
 select * from testmulticorn limit 1;
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_column_options_test.sql
+++ b/test-2.7/sql/multicorn_column_options_test.sql
@@ -24,5 +24,7 @@ select * from testmulticorn limit 1;
 ALTER foreign table testmulticorn alter test1 options (add prefix 'test3');
 
 select * from testmulticorn limit 1;
+
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_error_test.sql
+++ b/test-2.7/sql/multicorn_error_test.sql
@@ -18,4 +18,5 @@ ALTER server multicorn_srv options (DROP wrapper);
 
 CREATE server multicorn_empty_srv foreign data wrapper multicorn;
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_logger_test.sql
+++ b/test-2.7/sql/multicorn_logger_test.sql
@@ -15,4 +15,5 @@ CREATE foreign table testmulticorn (
 -- Test "normal" usage
 select * from testmulticorn;
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_planner_test.sql
+++ b/test-2.7/sql/multicorn_planner_test.sql
@@ -38,5 +38,6 @@ explain select * from testmulticorn m1 inner join testmulticorn m2 on m1.test1 =
 
 explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.test1 = m2.test1;
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_regression_test.sql
+++ b/test-2.7/sql/multicorn_regression_test.sql
@@ -107,5 +107,6 @@ ALTER FOREIGN TABLE testmulticorn add test3 money;
 SELECT * from testmulticorn where test3 = 12::money;
 SELECT * from testmulticorn where test1 = '12 €';
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_sequence_test.sql
+++ b/test-2.7/sql/multicorn_sequence_test.sql
@@ -47,5 +47,7 @@ CREATE foreign table testmulticorn2 (
 );
 
 select * from testmulticorn union all select * from testmulticorn2;
+
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_test_date.sql
+++ b/test-2.7/sql/multicorn_test_date.sql
@@ -19,5 +19,7 @@ select * from testmulticorn;
 select * from testmulticorn where test1 < '2011-06-01';
 
 select * from testmulticorn where test2 < '2011-06-01 00:00:00';
+
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_test_dict.sql
+++ b/test-2.7/sql/multicorn_test_dict.sql
@@ -18,5 +18,7 @@ CREATE foreign table testmulticorn (
 select * from testmulticorn;
 
 select test1 -> 'repeater' as r from testmulticorn order by r;
+
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/multicorn_test_list.sql
+++ b/test-2.7/sql/multicorn_test_list.sql
@@ -32,5 +32,7 @@ alter foreign table testmulticorn alter test2 type varchar[][];
 select test1[2], test2[2][2], array_length(test1, 1), array_length(test2, 1), array_length(test2, 2) from testmulticorn limit 1;
 
 select length(test1[2]) from testmulticorn limit 1;
+
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/write_filesystem.sql
+++ b/test-2.7/sql/write_filesystem.sql
@@ -59,6 +59,7 @@ $$ language plpythonu;
 
 select cleanup_dir();
 
+SET client_min_messages=WARNING;
 DROP FUNCTION cleanup_dir();
 DROP TABLE temp_dir;
 DROP FUNCTION create_table();

--- a/test-2.7/sql/write_savepoints.sql
+++ b/test-2.7/sql/write_savepoints.sql
@@ -139,5 +139,6 @@ DROP foreign table testmulticorn_write;
 ROLLBACK;
 
 -- Clean up
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-2.7/sql/write_sqlalchemy.sql
+++ b/test-2.7/sql/write_sqlalchemy.sql
@@ -71,5 +71,6 @@ DELETE from testalchemy;
 
 SELECT * from basetable;
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
 DROP TABLE basetable;

--- a/test-2.7/sql/write_test.sql
+++ b/test-2.7/sql/write_test.sql
@@ -88,5 +88,6 @@ CREATE foreign table testmulticorn_write(
 	test_type 'date'
 );
 delete from testmulticorn_write;
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-3.3/expected/import_sqlalchemy.out
+++ b/test-3.3/expected/import_sqlalchemy.out
@@ -106,14 +106,7 @@ SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.o
  t2
 (2 rows)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table remote_schema.t1
-drop cascades to foreign table remote_schema.t2
 DROP SCHEMA local_schema CASCADE;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to table local_schema.t1
-drop cascades to table local_schema.t2
-drop cascades to table local_schema.t3
 DROP SCHEMA remote_schema CASCADE;

--- a/test-3.3/expected/import_test.out
+++ b/test-3.3/expected/import_test.out
@@ -37,8 +37,5 @@ SELECT relname FROM pg_class c INNER JOIN pg_namespace n on c.relnamespace = n.o
  imported_table_1
 (2 rows)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table import_dest1.imported_table_2
-drop cascades to foreign table import_dest1.imported_table_1

--- a/test-3.3/expected/multicorn_alchemy_test.out
+++ b/test-3.3/expected/multicorn_alchemy_test.out
@@ -196,8 +196,6 @@ select count(*) from testalchemy;
      4
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testalchemy
 DROP table basetable;

--- a/test-3.3/expected/multicorn_cache_invalidation.out
+++ b/test-3.3/expected/multicorn_cache_invalidation.out
@@ -311,8 +311,6 @@ NOTICE:  ['test2', 'testnew']
  test2 1 0 | test1 2 0
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/multicorn_column_options_test.out
+++ b/test-3.3/expected/multicorn_column_options_test.out
@@ -55,8 +55,6 @@ NOTICE:  ['test1', 'test2']
  test1 1 0 | test2 2 0
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/multicorn_error_test.out
+++ b/test-3.3/expected/multicorn_error_test.out
@@ -20,5 +20,5 @@ ALTER server multicorn_srv options (DROP wrapper);
 ERROR:  The wrapper parameter is mandatory, specify a valid class name
 CREATE server multicorn_empty_srv foreign data wrapper multicorn;
 ERROR:  The wrapper parameter is mandatory, specify a valid class name
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to server multicorn_srv

--- a/test-3.3/expected/multicorn_logger_test.out
+++ b/test-3.3/expected/multicorn_logger_test.out
@@ -16,7 +16,5 @@ NOTICE:  [('option1', 'option1'), ('test_type', 'logger')]
 NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
 WARNING:  An error is about to occur
 ERROR:  An error occured
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/multicorn_planner_test.out
+++ b/test-3.3/expected/multicorn_planner_test.out
@@ -76,8 +76,6 @@ explain select * from testmulticorn m1 left outer join testmulticorn m2 on m1.te
          Filter: ((m1.test1)::text = (test1)::text)
 (4 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/multicorn_regression_test.out
+++ b/test-3.3/expected/multicorn_regression_test.out
@@ -473,9 +473,6 @@ NOTICE:  ['test1', 'test2', 'test3']
 -------+-------+-------
 (0 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
-drop cascades to foreign table testmulticorn2

--- a/test-3.3/expected/multicorn_sequence_test.out
+++ b/test-3.3/expected/multicorn_sequence_test.out
@@ -330,9 +330,6 @@ NOTICE:  ['test1', 'test2']
  test1 3 19 | test2 1 19
 (40 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
-drop cascades to foreign table testmulticorn2

--- a/test-3.3/expected/multicorn_test_date.out
+++ b/test-3.3/expected/multicorn_test_date.out
@@ -75,8 +75,6 @@ NOTICE:  ['test1', 'test2']
  05-03-2011 | Sun May 01 14:30:25 2011
 (10 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/multicorn_test_dict.out
+++ b/test-3.3/expected/multicorn_test_dict.out
@@ -69,8 +69,6 @@ NOTICE:  ['test1']
  3
 (20 rows)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/multicorn_test_list.out
+++ b/test-3.3/expected/multicorn_test_list.out
@@ -129,8 +129,6 @@ NOTICE:  ['test1']
      26
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/write_filesystem.out
+++ b/test-3.3/expected/write_filesystem.out
@@ -591,11 +591,9 @@ select cleanup_dir();
  
 (1 row)
 
+SET client_min_messages=WARNING;
 DROP FUNCTION cleanup_dir();
 DROP TABLE temp_dir;
 DROP FUNCTION create_table();
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
 DROP LANGUAGE plpython3u;

--- a/test-3.3/expected/write_savepoints.out
+++ b/test-3.3/expected/write_savepoints.out
@@ -142,8 +142,6 @@ RELEASE A;
 DROP foreign table testmulticorn_write;
 ROLLBACK;
 -- Clean up
+SET client_min_messages=WARNING;
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn

--- a/test-3.3/expected/write_sqlalchemy.out
+++ b/test-3.3/expected/write_sqlalchemy.out
@@ -75,8 +75,6 @@ SELECT * from basetable;
 ----+-------+------------+----------+----------
 (0 rows)
 
+SET client_min_messages=WARNING;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 2 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testalchemy
 DROP TABLE basetable;

--- a/test-3.3/expected/write_test.out
+++ b/test-3.3/expected/write_test.out
@@ -182,9 +182,6 @@ delete from testmulticorn_write;
 NOTICE:  [('option1', 'option1'), ('row_id_column', 'teststuff'), ('test_type', 'date'), ('usermapping', 'test')]
 NOTICE:  [('test1', 'date'), ('test2', 'timestamp without time zone')]
 ERROR:  The rowid attribute does not exist
+SET client_min_messages=WARNING;
 DROP USER MAPPING for postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
-DETAIL:  drop cascades to server multicorn_srv
-drop cascades to foreign table testmulticorn
-drop cascades to foreign table testmulticorn_write

--- a/test-3.3/sql/write_filesystem.sql
+++ b/test-3.3/sql/write_filesystem.sql
@@ -60,6 +60,7 @@ $$ language plpython3u;
 
 select cleanup_dir();
 
+SET client_min_messages=WARNING;
 DROP FUNCTION cleanup_dir();
 DROP TABLE temp_dir;
 DROP FUNCTION create_table();


### PR DESCRIPTION
DROP CASCADE outputs vary slightly in the DETAIL part:
-drop cascades to user mapping for postgres
+drop cascades to user mapping for postgres on server multicorn_srv

Suppress these using SET client_min_messages=WARNING;

(I haven't actually verified how much these variations depend on the PG version used. If it matters I can so some digging, but I'd think the messages aren't really interesting so dropping them is a good idea anyway.)

Original patch by Markus Wanner.
