### PR TITLE
Change shebang to #!/bin/sh as it's a valid POSIX sh

### DIFF
--- a/preflight-check.sh
+++ b/preflight-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PG_CONFIG=$(which pg_config)
 PY_VERSION=$(python --version 2>&1 | awk '{ print substr($2,1,3)}')


### PR DESCRIPTION
This allows the file to run on systems that don't have bash (like *BSD)

Tested on OpenBSD - works!
