### PR TITLE
Write minimal columns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ directories.stamp:
 
 $(OBJS): directories.stamp
 
-install: python_code 
+install: python_code
+
+rpm: setup.py
+	@echo "About to make RPM"
+	$(PYTHON) ./setup.py bdist --format=rpm
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql directories.stamp
 	cp $< $@

--- a/multicorn.control
+++ b/multicorn.control
@@ -1,4 +1,4 @@
 comment = 'Multicorn Python bindings for Postgres 9.2.* Foreign Data Wrapper'
 default_version = '1.3.2'
 module_pathname = '$libdir/multicorn'
-relocatable = true
+relocatable = True

--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -353,7 +353,7 @@ class ForeignDataWrapper(object):
 
     def update(self, oldvalues, newvalues):
         """
-        Update a tuple containing ''oldvalues'' to the ''newvalues''.
+        Update a identified by ''rowid''  to the ''newvalues''.
 
         Args:
             oldvalues (dict): a dictionary mapping from column
@@ -365,6 +365,14 @@ class ForeignDataWrapper(object):
             for information about this return value.
         """
         raise NotImplementedError("This FDW does not support the writable API")
+
+    def update(self, rowid, update_columns, newvalues):
+        """
+        Update only the columns identified in ''update_columns''
+        Identify the row by the rowid parameter.
+        If this object is not overloaded by the derriving class then call the old API (without the update_columns parameter)
+        """
+        return self.update(rowid, newvalues)
 
     def delete(self, oldvalues):
         """

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,12 @@ import subprocess
 import sys
 from setuptools import setup, find_packages, Extension
 
+
+import os
+from sys import platform
+from setuptools.command.install import install
+from distutils.command.build import build
+
 # hum... borrowed from psycopg2
 def get_pg_config(kind, pg_config="pg_config"):
     p = subprocess.Popen([pg_config, '--%s' % kind], stdout=subprocess.PIPE)
@@ -26,12 +32,37 @@ if sys.version_info[0] == 2:
     elif sys.version_info[1] < 6:
         sys.exit("Sorry, you need at least python 2.6 for Multicorn")
 
+class MulticornBuild(build):
+  def run(self):
+    # Original build
+    build.run(self)
+    r = subprocess.check_output(['/usr/bin/make', 'multicorn.so'])
+    r = r.strip().decode('utf8')
+    if not r:
+      raise Warning(p[2].readline())
+    # After original build
+
+execfile('multicorn.control')
+
+
 setup(
- name='multicorn',
- version='__VERSION__',
- author='Kozea',
- license='Postgresql',
- package_dir={'': 'python'},
- packages=['multicorn', 'multicorn.fsfdw'],
- ext_modules = [multicorn_utils_module]
-)
+    name='multicorn',
+    # version='__VERSION__',
+    version=default_version,
+    author='Kozea',
+    license='Postgresql',
+    options={'bdist_rpm': {'post_install': 'rpm/post_install.sh',
+                           'pre_uninstall': 'rpm/pre_uninstall.sh',
+                           'requires': 'postgresql95-server',
+                           }},
+    package_dir={'': 'python'},
+    packages=['multicorn', 'multicorn.fsfdw'],
+    ext_modules=[multicorn_utils_module],
+    data_files=[
+        ('%s/extension' % get_pg_config('sharedir'), ['multicorn.control', 'sql/multicorn.sql', 'doc/multicorn.md']),
+        (get_pg_config('libdir'), ['multicorn.so'])
+        ],
+    cmdclass={
+        'build': MulticornBuild,
+        }
+    )

--- a/src/errors.c
+++ b/src/errors.c
@@ -15,11 +15,7 @@
 #include "multicorn.h"
 #include "bytesobject.h"
 #include "access/xact.h"
-
-void reportException(PyObject *pErrType,
-				PyObject *pErrValue,
-				PyObject *pErrTraceback);
-
+#include "errors.h"
 
 void
 errorCheck()

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,0 +1,12 @@
+#include "multicorn.h"
+#include "bytesobject.h"
+#include "access/xact.h"
+
+
+#ifndef PG_ERRORS_H
+#define PG_ERRORS_H
+
+void errorCheck(void);
+void reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback);
+
+#endif

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -91,6 +91,7 @@ typedef struct MulticornModifyState
 	AttrNumber	rowidAttno;
 	char	   *rowidAttrName;
 	ConversionInfo *rowidCinfo;
+    List* update_columns_list;
 }	MulticornModifyState;
 
 

--- a/src/python.c
+++ b/src/python.c
@@ -20,81 +20,12 @@
 #include "access/xact.h"
 #include "utils/lsyscache.h"
 
+#include "python.h"
+#include "errors.h"
+#include "multicorn.h"
 
-List	   *getOptions(Oid foreigntableid);
-bool		compareOptions(List *options1, List *options2);
-
-void		getColumnsFromTable(TupleDesc desc, PyObject **p_columns, List **columns);
-bool		compareColumns(List *columns1, List *columns2);
-
-PyObject   *getClass(PyObject *className);
-PyObject   *valuesToPySet(List *targetlist);
-PyObject   *qualDefsToPyList(List *quallist, ConversionInfo ** cinfo);
-PyObject *pythonQual(char *operatorname, PyObject *value,
-		   ConversionInfo * cinfo,
-		   bool is_array,
-		   bool use_or,
-		   Oid typeoid);
-
-PyObject  *getSortKey(MulticornDeparsedSortGroup *key);
-MulticornDeparsedSortGroup *getDeparsedSortGroup(PyObject *key);
-
-
-Datum pyobjectToDatum(PyObject *object, StringInfo buffer,
-				ConversionInfo * cinfo);
-PyObject   *qualdefToPython(MulticornConstQual * qualdef, ConversionInfo ** cinfo);
-PyObject *paramDefToPython(List *paramdef, ConversionInfo ** cinfos,
-				 Oid typeoid,
-				 Datum value);
-
-
-PyObject   *datumToPython(Datum node, Oid typeoid, ConversionInfo * cinfo);
-PyObject   *datumStringToPython(Datum node, ConversionInfo * cinfo);
-PyObject   *datumNumberToPython(Datum node, ConversionInfo * cinfo);
-PyObject   *datumDateToPython(Datum datum, ConversionInfo * cinfo);
-PyObject   *datumTimestampToPython(Datum datum, ConversionInfo * cinfo);
-PyObject   *datumIntToPython(Datum datum, ConversionInfo * cinfo);
-PyObject   *datumArrayToPython(Datum datum, Oid type, ConversionInfo * cinfo);
-PyObject   *datumByteaToPython(Datum datum, ConversionInfo * cinfo);
-PyObject   *datumUnknownToPython(Datum datum, ConversionInfo * cinfo, Oid type);
-
-
-void pythonDictToTuple(PyObject *p_value,
-				  TupleTableSlot *slot,
-				  ConversionInfo ** cinfos,
-				  StringInfo buffer);
-
-void pythonSequenceToTuple(PyObject *p_value,
-					  TupleTableSlot *slot,
-					  ConversionInfo ** cinfos,
-					  StringInfo buffer);
-
-/* Python to cstring functions */
-void pyobjectToCString(PyObject *pyobject, StringInfo buffer,
-				  ConversionInfo * cinfo);
-
-void pynumberToCString(PyObject *pyobject, StringInfo buffer,
-				  ConversionInfo * cinfo);
-void pyunicodeToCString(PyObject *pyobject, StringInfo buffer,
-				   ConversionInfo * cinfo);
-void pystringToCString(PyObject *pyobject, StringInfo buffer,
-				  ConversionInfo * cinfo);
-void pysequenceToCString(PyObject *pyobject, StringInfo buffer,
-					ConversionInfo * cinfo);
-void pymappingToCString(PyObject *pyobject, StringInfo buffer,
-				   ConversionInfo * cinfo);
-void pydateToCString(PyObject *pyobject, StringInfo buffer,
-				ConversionInfo * cinfo);
-
-void pyunknownToCstring(PyObject *pyobject, StringInfo buffer,
-				   ConversionInfo * cinfo);
-
-void appendBinaryStringInfoQuote(StringInfo buffer,
-							char *tempbuffer,
-							Py_ssize_t strlength,
-							bool need_quote);
-
-
+/* Static FWD definitions
+ */
 static void begin_remote_xact(CacheEntry * entry);
 
 /*

--- a/src/python.h
+++ b/src/python.h
@@ -1,0 +1,83 @@
+#include <Python.h>
+#include "datetime.h"
+#include "postgres.h"
+#include "multicorn.h"
+#include "catalog/pg_user_mapping.h"
+#include "access/reloptions.h"
+#include "miscadmin.h"
+#include "utils/numeric.h"
+#include "utils/date.h"
+#include "utils/timestamp.h"
+#include "utils/array.h"
+#include "utils/catcache.h"
+#include "utils/memutils.h"
+#include "utils/resowner.h"
+#include "utils/rel.h"
+#include "utils/rel.h"
+#include "executor/nodeSubplan.h"
+#include "bytesobject.h"
+#include "mb/pg_wchar.h"
+#include "access/xact.h"
+#include "utils/lsyscache.h"
+
+
+
+#ifndef PG_PYTHON_H
+#define PG_PYTHON_H
+
+const char * getPythonEncodingName(void);
+char * PyUnicode_AsPgString(PyObject *p_unicode);
+
+#if PY_MAJOR_VERSION >= 3
+    PyObject * PyString_FromStringAndSize(const char *s, Py_ssize_t size);
+    PyObject * PyString_FromString(const char *s);
+    char * PyString_AsString(PyObject *unicode);
+    int PyString_AsStringAndSize(PyObject *obj, char **buffer, Py_ssize_t *length);
+#endif   /* PY_MAJOR_VERSION >= 3 */
+
+PyObject * getClass(PyObject *className);
+void appendBinaryStringInfoQuote(StringInfo buffer, char *tempbuffer, Py_ssize_t strlength, bool need_quote);
+PyObject * valuesToPySet(List *targetlist);
+PyObject * qualDefsToPyList(List *qual_list, ConversionInfo ** cinfos);
+PyObject * getClassString(const char *className);
+List * getOptions(Oid foreigntableid);
+UserMapping * multicorn_GetUserMapping(Oid userid, Oid serverid);
+PyObject * optionsListToPyDict(List *options);
+bool compareOptions(List *options1, List *options2);
+void getColumnsFromTable(TupleDesc desc, PyObject **p_columns, List **columns);
+bool compareColumns(List *columns1, List *columns2);
+CacheEntry * getCacheEntry(Oid foreigntableid);
+PyObject * getInstance(Oid foreigntableid);
+void getRelSize(MulticornPlanState * state, PlannerInfo *root, double *rows, int *width);
+PyObject * qualdefToPython(MulticornConstQual * qualdef, ConversionInfo ** cinfos);
+PyObject * pythonQual(char *operatorname, PyObject *value, ConversionInfo * cinfo, bool is_array, bool use_or, Oid typeoid);
+PyObject  * getSortKey(MulticornDeparsedSortGroup *key);
+MulticornDeparsedSortGroup * getDeparsedSortGroup(PyObject *sortKey);
+PyObject * execute(ForeignScanState *node, ExplainState *es);
+void pynumberToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pyunicodeToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pystringToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pysequenceToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pymappingToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pydateToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pyobjectToCString(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pyunknownToCstring(PyObject *pyobject, StringInfo buffer, ConversionInfo * cinfo);
+void pythonDictToTuple(PyObject *p_value, TupleTableSlot *slot, ConversionInfo ** cinfos, StringInfo buffer);
+void pythonSequenceToTuple(PyObject *p_value, TupleTableSlot *slot, ConversionInfo ** cinfos, StringInfo buffer);
+void pythonResultToTuple(PyObject *p_value, TupleTableSlot *slot, ConversionInfo ** cinfos, StringInfo buffer);
+Datum pyobjectToDatum(PyObject *object, StringInfo buffer, ConversionInfo * cinfo);
+PyObject * datumStringToPython(Datum datum, ConversionInfo * cinfo);
+PyObject * datumUnknownToPython(Datum datum, ConversionInfo * cinfo, Oid type);
+PyObject * datumNumberToPython(Datum datum, ConversionInfo * cinfo);
+PyObject * datumDateToPython(Datum datum, ConversionInfo * cinfo);
+PyObject * datumTimestampToPython(Datum datum, ConversionInfo * cinfo);
+PyObject * datumIntToPython(Datum datum, ConversionInfo * cinfo);
+PyObject * datumArrayToPython(Datum datum, Oid type, ConversionInfo * cinfo);
+PyObject * datumByteaToPython(Datum datum, ConversionInfo * cinfo);
+PyObject * datumToPython(Datum datum, Oid type, ConversionInfo * cinfo);
+List * pathKeys(MulticornPlanState * state);
+List * canSort(MulticornPlanState * state, List *deparsed);
+PyObject * tupleTableSlotToPyObject(TupleTableSlot *slot, ConversionInfo ** cinfos);
+char * getRowIdColumn(PyObject *fdw_instance);
+
+#endif

--- a/src/query.c
+++ b/src/query.c
@@ -11,39 +11,8 @@
 #include "miscadmin.h"
 #include "parser/parsetree.h"
 
-void extractClauseFromOpExpr(Relids base_relids,
-						OpExpr *node,
-						List **quals);
-
-void extractClauseFromNullTest(Relids base_relids,
-						  NullTest *node,
-						  List **quals);
-
-void extractClauseFromScalarArrayOpExpr(Relids base_relids,
-								   ScalarArrayOpExpr *node,
-								   List **quals);
-
-char	   *getOperatorString(Oid opoid);
-
-MulticornBaseQual *makeQual(AttrNumber varattno, char *opname, Expr *value,
-		 bool isarray,
-		 bool useOr);
-
-
-Node	   *unnestClause(Node *node);
-void swapOperandsAsNeeded(Node **left, Node **right, Oid *opoid,
-					 Relids base_relids);
-OpExpr	   *canonicalOpExpr(OpExpr *opExpr, Relids base_relids);
-ScalarArrayOpExpr *canonicalScalarArrayOpExpr(ScalarArrayOpExpr *opExpr,
-						   Relids base_relids);
-
-bool isAttrInRestrictInfo(Index relid, AttrNumber attno,
-					 RestrictInfo *restrictinfo);
-
-List *clausesInvolvingAttr(Index relid, AttrNumber attnum,
-					 EquivalenceClass *eq_class);
-
-Expr *multicorn_get_em_expr(EquivalenceClass *ec, RelOptInfo *rel);
+#include "query.h"
+#include "python.h"
 
 /*
  * The list of needed columns (represented by their respective vars)

--- a/src/query.h
+++ b/src/query.h
@@ -1,0 +1,29 @@
+
+
+
+#ifndef PG_QUERY_H
+#define PG_QUERY_H
+
+List * extractColumns(List *reltargetlist, List *restrictinfolist);
+void initConversioninfo(ConversionInfo ** cinfos, AttInMetadata *attinmeta);
+char * getOperatorString(Oid opoid);
+Node * unnestClause(Node *node);
+void swapOperandsAsNeeded(Node **left, Node **right, Oid *opoid, Relids base_relids);
+OpExpr * canonicalOpExpr(OpExpr *opExpr, Relids base_relids);
+ScalarArrayOpExpr * canonicalScalarArrayOpExpr(ScalarArrayOpExpr *opExpr, Relids base_relids);
+void extractRestrictions(Relids base_relids, Expr *node, List **quals);
+void extractClauseFromOpExpr(Relids base_relids, OpExpr *op, List **quals);
+void extractClauseFromScalarArrayOpExpr(Relids base_relids, ScalarArrayOpExpr *op, List **quals);
+void extractClauseFromNullTest(Relids base_relids, NullTest *node, List **quals);
+Value * colnameFromVar(Var *var, PlannerInfo *root, MulticornPlanState * planstate);
+MulticornBaseQual * makeQual(AttrNumber varattno, char *opname, Expr *value, bool isarray, bool useOr);
+bool isAttrInRestrictInfo(Index relid, AttrNumber attno, RestrictInfo *restrictinfo);
+List * clausesInvolvingAttr(Index relid, AttrNumber attnum, EquivalenceClass *ec);
+void computeDeparsedSortGroup(List *deparsed, MulticornPlanState *planstate, List **apply_pathkeys, List **deparsed_pathkeys);
+List * findPaths(PlannerInfo *root, RelOptInfo *baserel, List *possiblePaths, int startupCost, MulticornPlanState *state, List *apply_pathkeys, List *deparsed_pathkeys);
+List * deparse_sortgroup(PlannerInfo *root, Oid foreigntableid, RelOptInfo *rel);
+Expr * multicorn_get_em_expr(EquivalenceClass *ec, RelOptInfo *rel);
+List * serializeDeparsedSortGroup(List *pathkeys);
+List * deserializeDeparsedSortGroup(List *items);
+
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -16,19 +16,9 @@
 #include "postgres.h"
 #include "multicorn.h"
 #include "miscadmin.h"
-
-
-struct module_state
-{
-	PyObject   *error;
-};
-
-#if PY_MAJOR_VERSION >= 3
-#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
-#else
-#define GETSTATE(m) (&_state)
-static struct module_state _state;
-#endif
+#include "utils.h"
+#include "python.h"
+#include "errors.h"
 
 static PyObject *
 log_to_postgres(PyObject *self, PyObject *args, PyObject *kwargs)
@@ -130,43 +120,48 @@ static PyMethodDef UtilsMethods[] = {
 	{NULL, NULL, 0, NULL}
 };
 
+
+
 #if PY_MAJOR_VERSION >= 3
 
 static struct PyModuleDef moduledef = {
-	PyModuleDef_HEAD_INIT,
-	"multicorn._utils",
-	NULL,
-	sizeof(struct module_state),
-	UtilsMethods,
-	NULL,
-	NULL,
-	NULL,
-	NULL
+    PyModuleDef_HEAD_INIT,
+    "multicorn._utils",
+    NULL,
+    sizeof(struct module_state),
+    UtilsMethods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
 };
-
-#define INITERROR return NULL
 
 PyObject *
 PyInit__utils(void)
+{
+    PyObject   *module = PyModule_Create(&moduledef);
+    struct module_state *st;
+
+    if (module == NULL)
+		return NULL;
+
+	st = ((struct module_state*)PyModule_GetState(module))
+
+	return module;
+}
 #else
-#define INITERROR return
+
+// static struct module_state _state;
 
 void
 init_utils(void)
-#endif
 {
-#if PY_MAJOR_VERSION >= 3
-	PyObject   *module = PyModule_Create(&moduledef);
-#else
-	PyObject   *module = Py_InitModule("multicorn._utils", UtilsMethods);
-#endif
-	struct module_state *st;
+    PyObject   *module = Py_InitModule("multicorn._utils", UtilsMethods);
+    // struct module_state *st;
 
-	if (module == NULL)
-		INITERROR;
-	st = GETSTATE(module);
+    if (module == NULL)
+		return;
 
-#if PY_MAJOR_VERSION >= 3
-	return module;
-#endif
+	// st = &_state;
 }
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,24 @@
+
+
+
+
+#ifndef PG_UTILS_H
+#define PG_UTILS_H
+
+
+struct module_state
+{
+	PyObject   *error;
+};
+
+static PyObject * log_to_postgres(PyObject *self, PyObject *args, PyObject *kwargs);
+static PyObject * py_check_interrupts(PyObject *self, PyObject *args, PyObject *kwargs);
+
+#if PY_MAJOR_VERSION >= 3
+PyObject * PyInit__utils(void);
+#else
+void init_utils(void);
+#endif
+
+
+#endif


### PR DESCRIPTION
When doing UPDATE operations the current API will read the whole record and then write a complete new record.
This update only reads the columns specifically requested and only writes the columns specifically requested so minimising back and forth to the foreign server.