### PR TITLE
Added check for NULL in getRowIDColumn.

### DIFF
--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -402,6 +402,26 @@ class ForeignDataWrapper(object):
         """
         pass
 
+    def release_before(self):
+        """
+        Hook called just before locks are released after a commit.
+        """
+        pass
+
+    def release(self):
+        """
+        Hook called to release locks after a commit.
+        """
+        pass
+    
+    def release_after(self):
+        """
+        Hook called just after locks are released after a commit.
+        Useful if you need to mess with the database and need to
+        wait for locks to be released.
+        """
+        pass
+    
     def end_scan(self):
         """
         Hook called at the end of a foreign scan.

--- a/python/multicorn/utils.py
+++ b/python/multicorn/utils.py
@@ -1,13 +1,47 @@
+
 from logging import ERROR, INFO, DEBUG, WARNING, CRITICAL
 try:
     from ._utils import _log_to_postgres
     from ._utils import check_interrupts
+    from ._utils import _execute
+    from ._utils import _prepare
+    from ._utils import _execute_stmt
+    from ._utils import _fetch
 except ImportError as e:
     from warnings import warn
     warn("Not executed in a postgresql server,"
          " disabling log_to_postgres", ImportWarning)
 
     def _log_to_postgres(message, level=0, hint=None, detail=None):
+        pass
+
+    def _execute(sql, readonly, count):
+        pass
+
+    def _prepare(sql, *argv):
+        """
+        _prepare takes a sql statement and a
+        list of converter objects.  The 
+        converter objects define getOID
+        to get the postgres oid for 
+        that argument and a getdataum method.
+        The getdatum method returns the
+        takes two a single object as
+        an argument (as well as self) and
+        returns the value of that argument
+        as something the sql converter
+        can understand.  Currently this is limited
+        to a string, long, int, or float.  So
+        for example dates and time stamps would
+        have to be passed in as strings and
+        the sql would have to convert them.
+        """
+        pass
+
+    def _execute_stmt(stmt, args, converters):
+        pass
+
+    def _fetch():
         pass
 
 
@@ -19,10 +53,115 @@ REPORT_CODES = {
     CRITICAL: 4
 }
 
+class StatementException(Exception):
+    pass
+
+class Statement(object):
+    type_map = None
+
+    simple_converters = {
+        'int8': { 'func': lambda x: int(x) },
+        'int4': { 'func': lambda x: int(x) },
+        'float8': {'func': lambda x: float(x) },
+        'text': { 'lob': True },
+    }
+    
+    class Converter(object):
+        converter_map = {}
+        
+        def __init__(self, pgtype, **kwargs):
+            self.pgtype = pgtype
+            self.lob = kwargs.get('lob', False)
+            
+
+        def isLob(self):
+            return self.lob
+        
+        def getdatum(self, obj):
+            return obj
+
+        def getOID(self):
+            oid = Statement.getOID(self.pgtype);
+            return oid
+
+    @staticmethod
+    def converter(*args):
+        def decorator(cls):
+            for name in args:
+                Converter.converter_map[name]=cls
+            return cls
+        return decorator
+
+    for c,p in simple_converters.items():
+        name="SimpleConverter%s" %c
+        
+        d = {
+            '__init__': lambda s, n=c, p=p: Statement.Converter.__init__(s, n, **p)
+        }
+
+        if 'func' in p:
+            d['getdatum'] = lambda s, o, f=p['func']: f(o)
+
+        Converter.converter_map[c] = type(name, (Converter,), d)
+            
+
+    def __init__(self, sql, pytypes):
+        self.converters = []
+        self.results = None
+        for t in pytypes:
+            if t not in Statement.Converter.converter_map:
+                raise StatementException("Unhandled Data Type %s" %t)
+            self.converters.append(Statement.Converter.converter_map[t]())
+        self.stmt = prepare(sql, self.converters)
+
+    def execute(self, data):
+        ret = execute_stmt(self.stmt, data, self.converters)
+        self.results = fetch()
+
+    def getResults(self):
+        return self.results
+            
+
+    @staticmethod
+    def getOID(typname):
+        # not thread safe.
+        # XXXXX FIXME, need to consider namespaces.
+        if Statement.type_map is None:
+            sql = "select typname, oid::int4 from pg_type;"
+            res = execute(sql)
+            types = fetch()
+            Statement.type_map = {}
+            for t in types:
+                Statement.type_map[t['typname']] = t['oid']
+
+        return Statement.type_map.get(typname, None)
+
+            
+
 
 def log_to_postgres(message, level=INFO, hint=None, detail=None):
     code = REPORT_CODES.get(level, None)
     if code is None:
         raise KeyError("Not a valid log level")
     _log_to_postgres(message, code, hint=hint, detail=detail)
+
+
+def execute(sql, read_only=False, count=0):
+    return _execute(sql, None, count)
+
+def prepare(sql, converters):
+    return _prepare(sql, *converters)
+
+def execute_stmt(plan, args, converters):
+    if not isinstance(args, tuple):
+        args = tuple( a for a in args )
+
+    if not isinstance(converters, tuple):
+        converters = tuple (c for c in converters );
+        
+    return _execute_stmt(plan, args, converters)
+
+def fetch():
+    return _fetch()
+            
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ include_dirs = [get_pg_config(d) for d in ("includedir", "pkgincludedir", "inclu
 
 multicorn_utils_module = Extension('multicorn._utils',
         include_dirs=include_dirs,
-        extra_compile_args = ['-shared'],
+        extra_compile_args = ['-shared', '-g'],
         sources=['src/utils.c'])
 
 requires=[]

--- a/src/errors.c
+++ b/src/errors.c
@@ -54,8 +54,8 @@ reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback
 	errValue = PyString_AsString(PyObject_Str(pErrValue));
 	if (pErrTraceback != NULL)
 	{
-		traceback_list = PyObject_CallFunction(format_exception, "(O,O,O)", pErrType, pErrValue, pErrTraceback);
-		errTraceback = PyString_AsString(PyObject_CallMethod(newline, "join", "(O)", traceback_list));
+		traceback_list = PYOBJECT_CALLFUNCTION(format_exception, "(O,O,O)", pErrType, pErrValue, pErrTraceback);
+		errTraceback = PyString_AsString(PYOBJECT_CALLMETHOD(newline, "join", "(O)", traceback_list));
 		Py_DECREF(pErrTraceback);
 		Py_DECREF(traceback_list);
 	}

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -194,6 +194,14 @@ PyObject   *datumToPython(Datum node, Oid typeoid, ConversionInfo * cinfo);
 List	*serializeDeparsedSortGroup(List *pathkeys);
 List	*deserializeDeparsedSortGroup(List *items);
 
+/* pass through the PyObject to make the macros easier. */
+extern PyObject *multicorn_disconnect(PyObject *);
+extern void multicorn_connect(void);
+
+#define PYOBJECT_CALLMETHOD(...)  multicorn_disconnect(PyObject_CallMethod(__VA_ARGS__))
+
+#define PYOBJECT_CALLFUNCTION(...) multicorn_disconnect(PyObject_CallFunction(__VA_ARGS__))
+
 #endif   /* PG_MULTICORN_H */
 
 char	   *PyUnicode_AsPgString(PyObject *p_unicode);
@@ -202,6 +210,6 @@ char	   *PyUnicode_AsPgString(PyObject *p_unicode);
 PyObject   *PyString_FromString(const char *s);
 PyObject   *PyString_FromStringAndSize(const char *s, Py_ssize_t size);
 char	   *PyString_AsString(PyObject *unicode);
-int			PyString_AsStringAndSize(PyObject *unicode, char **tempbuffer, Py_ssize_t *length);
+int	   PyString_AsStringAndSize(PyObject *unicode, char **tempbuffer, Py_ssize_t *length);
 
 #endif

--- a/src/python.c
+++ b/src/python.c
@@ -1691,9 +1691,11 @@ getRowIdColumn(PyObject *fdw_instance)
 	char	   *result;
 
 	errorCheck();
-	if (value == Py_None)
+	if (value == Py_None || value == NULL)
 	{
-		Py_DECREF(value);
+	        if (value != NULL) {
+		        Py_DECREF(value);
+		}
 		elog(ERROR, "This FDW does not support the writable API");
 	}
 	result = PyString_AsString(value);

--- a/src/utils.c
+++ b/src/utils.c
@@ -12,16 +12,22 @@
  *
  *-------------------------------------------------------------------------
  */
+#include <stdio.h>
 #include <Python.h>
+
 #include "postgres.h"
 #include "multicorn.h"
 #include "miscadmin.h"
-
+#include "executor/spi.h"
 
 struct module_state
 {
 	PyObject   *error;
 };
+
+/* Used to name the PyCapsule type */
+#define STATEMENT_NAME "prepared statement"
+
 
 #if PY_MAJOR_VERSION >= 3
 #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
@@ -35,36 +41,36 @@ log_to_postgres(PyObject *self, PyObject *args, PyObject *kwargs)
 {
 	char	   *message = NULL;
 	char	   *hintstr = NULL,
-			   *detailstr = NULL;
+	*detailstr = NULL;
 	int			level = 1;
 	int			severity;
 	PyObject   *hint,
-			   *p_message,
-			   *detail;
+	*p_message,
+	*detail;
 
 	if (!PyArg_ParseTuple(args, "O|i", &p_message, &level))
 	{
-		errorCheck();
-		Py_INCREF(Py_None);
-		return Py_None;
+	  errorCheck();
+	  Py_INCREF(Py_None);
+	  return Py_None;
 	}
 	if (PyBytes_Check(p_message))
 	{
-		message = PyBytes_AsString(p_message);
+	  message = PyBytes_AsString(p_message);
 	}
 	else if (PyUnicode_Check(p_message))
 	{
-		message = strdup(PyUnicode_AsPgString(p_message));
+	  message = strdup(PyUnicode_AsPgString(p_message));
 	}
 	else
 	{
 
-		PyObject   *temp = PyObject_Str(p_message);
+	  PyObject   *temp = PyObject_Str(p_message);
 
-		errorCheck();
-		message = strdup(PyString_AsString(temp));
-		errorCheck();
-		Py_DECREF(temp);
+	  errorCheck();
+	  message = strdup(PyString_AsString(temp));
+	  errorCheck();
+	  Py_DECREF(temp);
 	}
 	switch (level)
 	{
@@ -87,29 +93,30 @@ log_to_postgres(PyObject *self, PyObject *args, PyObject *kwargs)
 			severity = INFO;
 			break;
 	}
+	
 	hint = PyDict_GetItemString(kwargs, "hint");
 	detail = PyDict_GetItemString(kwargs, "detail");
 	if (errstart(severity, __FILE__, __LINE__, PG_FUNCNAME_MACRO, TEXTDOMAIN))
 	{
-		errmsg("%s", message);
-		if (hint != NULL && hint != Py_None)
-		{
-			hintstr = PyString_AsString(hint);
-			errhint("%s", hintstr);
-		}
-		if (detail != NULL && detail != Py_None)
-		{
-			detailstr = PyString_AsString(detail);
-			errdetail("%s", detailstr);
-		}
-		Py_DECREF(args);
-		Py_DECREF(kwargs);
-		errfinish(0);
+	  errmsg("%s", message);
+	  if (hint != NULL && hint != Py_None)
+	  {
+	    hintstr = PyString_AsString(hint);
+	    errhint("%s", hintstr);
+	  }
+	  if (detail != NULL && detail != Py_None)
+	  {
+	    detailstr = PyString_AsString(detail);
+	    errdetail("%s", detailstr);
+	  }
+	  Py_DECREF(args);
+	  Py_DECREF(kwargs);
+	  errfinish(0);
 	}
 	else
 	{
-		Py_DECREF(args);
-		Py_DECREF(kwargs);
+	  Py_DECREF(args);
+	  Py_DECREF(kwargs);
 	}
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -123,10 +130,469 @@ py_check_interrupts(PyObject *self, PyObject *args, PyObject *kwargs)
 	return Py_None;
 }
 
+static void mylog(const char *m, const char *h, const char *d,
+		const char *f, int line,
+		const char *fn) {
+
+	FILE *fp = fopen("/tmp/mylog", "a");
+	fprintf(fp, "mylog(%s, %s, %s, %s, %d, %s)\n", m, h, d, f, line, fn);
+	fclose(fp);
+	
+	if (errstart(WARNING, f, line, fn, TEXTDOMAIN))
+	{
+	  errmsg("%s", m);
+	  if (h != NULL)
+	  {
+	    errhint("%s", h);
+	  }
+	  if (d != NULL)
+	  {
+	    errdetail("%s", d);
+	  }
+	  errfinish(0);
+	}
+}
+
+#define MYLOG(m, h, d) mylog(m, h, d, __FILE__, __LINE__, PG_FUNCNAME_MACRO)
+#define VLOG(...) do { snprintf(logbuff, sizeof(logbuff), __VA_ARGS__); MYLOG(logbuff, NULL, NULL); } while (0)
+
+static PyObject *
+py_fetch(PyObject *self, PyObject *args)
+{
+	PyObject *pret = NULL;
+	const size_t row_count = SPI_processed;
+	const size_t natts = SPI_tuptable != NULL ? SPI_tuptable->tupdesc->natts:0;
+	size_t i = 0;
+	int j = 0;
+	AttInMetadata *attinmeta = NULL;
+	ConversionInfo **cinfos = NULL;
+
+	/* We don't want any args, so ignore them. */
+	if (args != NULL)
+	{
+	  Py_DECREF(args);
+	  args = NULL;
+	}
+	/*
+	  return none if there are no tuples.
+	  This differs from returning an
+	  empty list if no rows were
+	  returned.
+	*/
+	
+	if (SPI_tuptable == NULL)
+	{
+	  pret = Py_None;
+	  Py_INCREF(pret);
+	  return pret;
+	}
+	
+	attinmeta = TupleDescGetAttInMetadata(SPI_tuptable->tupdesc);
+	
+	cinfos = SPI_palloc(sizeof(ConversionInfo *) * natts);
+	initConversioninfo(cinfos, attinmeta);
+	pret = PyTuple_New(row_count);
+  
+	if (pret == NULL)
+	{
+	  errorCheck();
+	  Py_INCREF(Py_None);
+	  pret = Py_None;
+	  return pret;
+	}
+
+	for (i = 0; i < row_count; ++i)
+	{
+	  PyObject   *rdict = PyDict_New();
+	  for (j = 0; j < natts; ++j) {
+	    Form_pg_attribute attr = TupleDescAttr(SPI_tuptable->tupdesc,j);
+	    PyObject *pobj = NULL;
+	    bool isnull = false;
+	    Datum d = SPI_getbinval(SPI_tuptable->vals[i],
+				    SPI_tuptable->tupdesc,
+				    j+1, &isnull);
+	    if (isnull == true)
+	    {
+	      Py_INCREF(Py_None);
+	      pobj = Py_None;
+	    }
+	    else
+	    {
+	      pobj = datumToPython(d, cinfos[attr->attnum - 1]->atttypoid,
+				   cinfos[attr->attnum - 1]);
+	      if (pobj == NULL)
+		{
+		  errorCheck();
+		  
+		  Py_DECREF(pret);
+		  pret = NULL;
+		  
+		  Py_DECREF(rdict);
+		  rdict = NULL;
+		  
+		  Py_INCREF(Py_None);
+		  pret = Py_None;
+		  return pret;
+		    
+		}
+	    }
+	    PyDict_SetItemString(rdict, cinfos[attr->attnum - 1]->attrname,
+				 pobj);
+	    Py_DECREF(pobj);
+	    pobj = NULL;
+	  }
+	  
+	  PyTuple_SetItem(pret, i, rdict);
+	  /* PyTupe_SetItem steals the reference,
+	     so we don't need to drop our reference
+	     to rdict.
+	  */
+	  rdict = NULL;
+	}
+	return pret;
+}
+
+static PyObject *
+py_execute_stmt(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	PyObject   *stmt_object = NULL;
+	SPIPlanPtr stmt = NULL;
+	PyObject   *pret = NULL;
+	PyObject   *pobj = NULL;
+	PyObject   *converter = NULL;
+	PyObject   *sqlargs_obj = NULL;
+	PyObject   *converters_obj = NULL;
+	Py_ssize_t arg_count = 0;
+	int        i = 0;
+	int	   iret = 0;
+	bool       read_only = false;
+	char       *nulls = NULL;
+	Datum      *stmt_args = NULL;
+
+	if (!PyArg_ParseTuple(args, "OO!O!", &stmt_object,
+			      &PyTuple_Type, &sqlargs_obj,
+			      &PyTuple_Type, &converters_obj))
+	{
+	  goto errout;
+	}
+
+	stmt = PyCapsule_GetPointer(stmt_object, STATEMENT_NAME);
+
+	if (stmt == NULL)
+	{
+	  goto errout;
+	}
+
+	arg_count = PyTuple_Size(sqlargs_obj);
+
+	multicorn_connect();
+	
+	if (arg_count != PyTuple_Size(converters_obj) ||
+	    arg_count != SPI_getargcount(stmt))
+	{
+	  /* XXXXX FIXME: throw arg count mismatch exception. */
+	  goto errout;
+	}
+	
+	nulls = (char *)SPI_palloc(sizeof(*nulls)*(arg_count+1));
+	memset (nulls, ' ', (arg_count+1)*sizeof(*nulls));
+	nulls[arg_count] = 0;
+	
+	stmt_args = (Datum *)SPI_palloc(sizeof(*stmt_args)*arg_count);
+	memset (stmt_args, 0, arg_count*sizeof(*stmt_args));
+
+	for (i = 0; i < arg_count; i++)
+	{
+	  PyObject *str=NULL;
+	  PyObject *islob_obj = NULL;
+	  bool islob = false;
+
+	  pobj = PyTuple_GetItem(sqlargs_obj, i);
+
+	  stmt_args[i] = Int64GetDatum(0);
+	    
+	  if (pobj == NULL || pobj == Py_None)
+	  {
+	    nulls[i] = 'n';
+	    continue;
+	  }
+
+	  nulls[i] = 'n';
+	  str = PyObject_Str(pobj);
+	  
+	  converter = PyTuple_GetItem(converters_obj, i);
+	  if (converter == NULL || converter == Py_None)
+	  {
+	    goto errout;
+	  }
+
+	  Py_DECREF(str);
+	  
+
+	  /* Don't use the macro here since we
+	     are in the middle of a pg call.
+	  */
+	  islob_obj = PyObject_CallMethod(converter, "isLob", "()");
+
+	  if (islob_obj == NULL)
+	  {
+	    goto errout;
+	  }
+	  
+	  islob = PyObject_IsTrue(islob_obj);
+	  Py_DECREF(islob_obj);
+
+	    
+	  pobj = PyObject_CallMethod(converter, "getdatum", "(O)", pobj);
+
+	  if (PyString_Check(pobj))
+	  {
+	    if (islob)
+	      {
+		stmt_args[i] = DirectFunctionCall1(textin,
+						   CStringGetDatum(pstrdup(PyString_AsString(pobj))));
+	      }
+	      else
+	      {
+		stmt_args[i]=CStringGetDatum(pstrdup(PyString_AsString(pobj)));
+	      }
+	  }
+	  else if (PyLong_Check(pobj))
+	  {
+	    stmt_args[i] = Int64GetDatum(PyLong_AsLong(pobj));
+	  }
+	  else if (PyInt_Check(pobj))
+	  {
+	    stmt_args[i] = Int32GetDatum(PyInt_AsLong(pobj));
+	  }
+	  else if (PyFloat_Check(pobj))
+	  {
+	    stmt_args[i] = Float8GetDatum(PyFloat_AsDouble(pobj));
+	  }
+
+	  stmt_args[i] = Int64GetDatum(0);
+	  
+	  Py_DECREF(pobj);
+
+	}
+
+	iret = SPI_execute_plan(stmt, stmt_args, nulls,
+				read_only, 0);
+
+	pret = PyInt_FromLong(iret);
+	if (pret == NULL)
+	{
+	  goto errout;
+	}
+	
+  out:
+	if (args != NULL)
+	{
+	  Py_DECREF(args);
+	}
+
+	if (kwargs != NULL)
+	{
+	  Py_DECREF(kwargs);
+	}
+
+	return pret;
+	
+  errout:
+	errorCheck();
+	Py_INCREF(Py_None);
+	pret = Py_None;
+	goto out;
+}
+
+static PyObject *
+py_execute(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	char	   *sql = NULL;
+	bool       read_only=false;
+	PyObject   *read_only_object = NULL;
+	int        count=0;
+	PyObject   *pret = NULL;
+	int        iret = 0;
+	
+	
+	if (!PyArg_ParseTuple(args, "sOi", &sql, &read_only_object, &count))
+	{
+	  errorCheck();
+	  if (args != NULL) {
+	    Py_DECREF(args);
+	  }
+
+	  if (kwargs != NULL) {
+	    Py_DECREF(kwargs);
+	  }
+
+	  Py_INCREF(Py_None);
+	  return Py_None;
+	}
+
+	read_only = PyObject_IsTrue(read_only_object);
+
+	multicorn_connect();
+	
+	iret = SPI_execute(sql, read_only, count);
+
+	if (args != NULL)
+	{
+	  Py_DECREF(args);
+	}
+
+	if (kwargs != NULL)
+	{
+	  Py_DECREF(kwargs);
+	}
+
+	pret = PyInt_FromLong(iret);
+	
+	return pret;
+}
+
+static void
+stmt_destructor(PyObject *po)
+{
+	SPIPlanPtr stmt = PyCapsule_GetPointer(po, STATEMENT_NAME);
+
+	if (stmt == NULL)
+	{
+	  errorCheck();
+	  return;
+	}
+
+	SPI_freeplan(stmt);
+}
+
+static PyObject *
+py_prepare(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+	char	   *sql = NULL;
+	PyObject   *pret = NULL;
+	PyObject   *pobj = NULL;
+	SPIPlanPtr stmt = NULL;
+	Py_ssize_t arg_count = 0;
+	Oid 	   *argtypes = NULL;
+	Py_ssize_t i;
+
+	arg_count = PyTuple_Size(args) - 1;
+	pobj = PyTuple_GetItem(args, 0);
+	if (pobj == NULL)
+	{
+	  goto errout;
+	}
+
+	sql = PyString_AsString(pobj);
+	
+	if (sql == NULL)
+	{
+	  goto errout;
+	}
+
+	multicorn_connect();
+
+	argtypes = SPI_palloc(sizeof(*argtypes) * arg_count);
+	if (argtypes == NULL) {
+	  goto errout;
+	}
+
+	memset(argtypes, 0, sizeof(*argtypes) * arg_count);
+	for (i = 0; i < arg_count; ++i)
+	{
+	  pobj = PyTuple_GetItem(args, i + 1);
+	  /* Don't use the macro here since we
+	     are in the middle of a pg call.
+	  */
+	  pobj = PyObject_CallMethod(pobj, "getOID", "()");
+	  if (pobj == NULL) {
+	    goto errout;
+	  }
+	  
+	  if (!PyLong_Check(pobj))
+	  {
+	    /* XXXXX Fixme:
+	       throw a type error.
+	    */
+	    Py_DECREF(pobj);
+	    goto errout;
+	  }
+	  
+	  argtypes[i] = PyLong_AsLong(pobj);
+	  Py_DECREF(pobj);
+	}
+
+	/* 
+	 * SPI_Prepare makes a copy
+	 * of the argtypes in _SPI_make_plan_non_temp
+	 * so we must still free it.
+	 */
+
+	
+	stmt = SPI_prepare(sql, arg_count, argtypes);
+
+	
+	if (stmt == NULL)
+	{
+	  goto errout;
+	}
+
+	if (SPI_keepplan(stmt))
+	{
+	  goto errout;
+	}
+
+	pret = PyCapsule_New(stmt, STATEMENT_NAME, stmt_destructor);
+	
+	if (pret == NULL)
+	{
+	  goto errout;
+	}
+
+  out:
+	if (args != NULL)
+	{
+	  Py_DECREF(args);
+	}
+	
+	if (kwargs != NULL)
+	{
+	  Py_DECREF(kwargs);
+	}
+
+	if (argtypes != NULL)
+	{
+	  SPI_pfree(argtypes);
+	}
+
+	return pret;
+
+  errout:
+	errorCheck();
+	pret = Py_None;
+	Py_INCREF(Py_None);
+	goto out;
+	  
+
+}
+
+
 
 static PyMethodDef UtilsMethods[] = {
-	{"_log_to_postgres", (PyCFunction) log_to_postgres, METH_VARARGS | METH_KEYWORDS, "Log to postresql client"},
-	{"check_interrupts", (PyCFunction) py_check_interrupts, METH_VARARGS | METH_KEYWORDS, "Gives control back to PostgreSQL"},
+	{"_log_to_postgres", (PyCFunction) log_to_postgres,
+	 METH_VARARGS | METH_KEYWORDS, "Log to postresql client"},
+	{"_execute", (PyCFunction) py_execute, METH_VARARGS | METH_KEYWORDS,
+	 "Execute SQL"},
+	{"_fetch", (PyCFunction) py_fetch, METH_VARARGS,
+	 "Fetch a tuple of results from last execute."},
+	{"_prepare", (PyCFunction) py_prepare,  METH_VARARGS | METH_KEYWORDS,
+	 "Prepare a statement to execute."},
+	{"_execute_stmt", (PyCFunction) py_execute_stmt,
+	 METH_VARARGS | METH_KEYWORDS,
+	 "Execute a previously prepared statement."},
+	{"check_interrupts", (PyCFunction) py_check_interrupts,
+	 METH_VARARGS | METH_KEYWORDS, "Gives control back to PostgreSQL"},
 	{NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
If I create a rowid_column method in python, PyObject_GetAttrString returns NULL.  Returning NULL causes a segfault in the calling code.  I've seen this reported as a bug and it's bitten me a couple of times.
