### PR TITLE
Changed import to fix error while creating server in postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ preflight-check:
 
 python_code: setup.py
 	cp $(srcdir)/setup.py ./setup--$(EXTVERSION).py
-	sed -i -e "s/__VERSION__/$(EXTVERSION)-dev/g" ./setup--$(EXTVERSION).py
+	sed -i -e "s/__VERSION__/$(EXTVERSION)/g" ./setup--$(EXTVERSION).py
 	$(PYTHON) ./setup--$(EXTVERSION).py install
 	rm ./setup--$(EXTVERSION).py
 

--- a/python/multicorn/sqlalchemyfdw.py
+++ b/python/multicorn/sqlalchemyfdw.py
@@ -165,8 +165,8 @@ except ImportError:
 
 from sqlalchemy.schema import Table, Column, MetaData
 from sqlalchemy.dialects.oracle import base as oracle_dialect
-from sqlalchemy.dialects.postgresql.base import (
-    ARRAY, ischema_names, PGDialect, NUMERIC)
+from sqlalchemy.dialects.postgresql.base import ( ischema_names, PGDialect, NUMERIC)
+from sqlalchemy.dialects.postgresql.array import ARRAY
 import re
 import operator
 


### PR DESCRIPTION
Fixes issue with imports in sqlalchemy.fdw where 

```
- Executing query:
create extension multicorn;
 
Query returned successfully with no result in 249 msec.
 
-- Executing query:
CREATE SERVER alchemy_srv
FOREIGN DATA WRAPPER multicorn
OPTIONS (wrapper 'multicorn.sqlalchemyfdw.SqlAlchemyFdw');
ERROR:  Error in python: ImportError
DETAIL:  cannot import name ARRAY
 
********** Error **********
 
ERROR: Error in python: ImportError
SQL state: XX000
Detail: cannot import name ARRAY
```

 
This error lead me to the following ticket on your issue tracker https://github.com/Kozea/Multicorn/issues/159
 
Changin the import from
```
from sqlalchemy.dialects.postgresql.base import (
    ARRAY, ischema_names, PGDialect, NUMERIC)
```
------- to
```
from sqlalchemy.dialects.postgresql.base import ( ischema_names, PGDialect, NUMERIC)
from sqlalchemy.dialects.postgresql.array import ARRAY
```