### PR TITLE
FilesystemFdw: Enhance pattern matching and timestamp support

### DIFF
--- a/python/multicorn/fsfdw/__init__.py
+++ b/python/multicorn/fsfdw/__init__.py
@@ -1,5 +1,4 @@
-"""
-Purpose
+"""Purpose
 -------
 
 This fdw can be used to access data stored in various files, in a filesystem.
@@ -37,6 +36,16 @@ Options
 
 ``file_mode`` (default: 700)
   The unix permission mask to be used when creating files.
+
+``escape_pattern`` (default: TRUE)
+  If TRUE, the pattern used to match files is escaped before it is
+  used for regular expression matching. If FALSE, the pattern used to
+  match files is used as is and it is assumed to be a valid regular
+  expression.
+
+``ignore_case`` (default: FALSE)
+  If FALSE, the pattern used to match files is case sensitive. If
+  TRUE, the pattern used to match files is case insensitive.
 
 Usage Example
 -------------

--- a/python/multicorn/fsfdw/__init__.py
+++ b/python/multicorn/fsfdw/__init__.py
@@ -138,11 +138,14 @@ class FilesystemFdw(TransactionAwareForeignDataWrapper):
         self.file_mode = int(options.get('file_mode', '700'), 8)
         escape_pattern = (options.get('escape_pattern', 'TRUE').upper() in
                           ('TRUE', 'T'))
+        ignore_case = (options.get('ignore_case', 'FALSE').upper() in
+                       ('TRUE', 'T'))
         self.structured_directory = StructuredDirectory(
             root_dir,
             pattern,
             file_mode=self.file_mode,
-            escape_pattern=escape_pattern)
+            escape_pattern=escape_pattern,
+            ignore_case=ignore_case)
         self.folder_columns = [key[0] for key in
                                self.structured_directory._path_parts_properties
                                if key]

--- a/python/multicorn/fsfdw/__init__.py
+++ b/python/multicorn/fsfdw/__init__.py
@@ -136,9 +136,13 @@ class FilesystemFdw(TransactionAwareForeignDataWrapper):
         self.content_column = options.get('content_column', None)
         self.filename_column = options.get('filename_column', None)
         self.file_mode = int(options.get('file_mode', '700'), 8)
+        escape_pattern = (options.get('escape_pattern', 'TRUE').upper() in
+                          ('TRUE', 'T'))
         self.structured_directory = StructuredDirectory(
-            root_dir, pattern,
-            file_mode=self.file_mode)
+            root_dir,
+            pattern,
+            file_mode=self.file_mode,
+            escape_pattern=escape_pattern)
         self.folder_columns = [key[0] for key in
                                self.structured_directory._path_parts_properties
                                if key]

--- a/python/multicorn/fsfdw/__init__.py
+++ b/python/multicorn/fsfdw/__init__.py
@@ -34,6 +34,12 @@ Options
 ``filename_column``
   If set, defines which column will contain the full filename.
 
+``mtime_column``
+  If set, defines which column will contain the file mtime.
+
+``ctime_column``
+  If set, defines which column will contain the file ctime.
+
 ``file_mode`` (default: 700)
   The unix permission mask to be used when creating files.
 

--- a/python/multicorn/fsfdw/structuredfs.py
+++ b/python/multicorn/fsfdw/structuredfs.py
@@ -192,8 +192,8 @@ class Item(collections.Mapping):
         self._properties = {}
         self.content = content
         self.actual_filename = actual_filename
-        self.mtime = datetime.datetime.fromtimestamp(mtime)
-        self.ctime = datetime.datetime.fromtimestamp(ctime)
+        self.mtime = datetime.datetime.fromtimestamp(mtime) if mtime else None
+        self.ctime = datetime.datetime.fromtimestamp(ctime) if ctime else None
         # TODO: check for ambiguities.
         # eg. with pattern = '{a}_{b}', values {'a': '1_2', 'b': '3'} and
         # {'a': '1', 'b': '2_3'} both give the same filename.

--- a/python/multicorn/fsfdw/structuredfs.py
+++ b/python/multicorn/fsfdw/structuredfs.py
@@ -92,7 +92,7 @@ def _tokenize_pattern(pattern):
 
 
 def _parse_pattern(pattern, escape_pattern=True, ignore_case=False):
-    """
+    r"""
     Parse a string pattern and return (path_parts_re, path_parts_properties)
 
     >>> _parse_pattern('{category}/{number}_{name}.txt')

--- a/python/multicorn/fsfdw/structuredfs.py
+++ b/python/multicorn/fsfdw/structuredfs.py
@@ -89,7 +89,7 @@ def _tokenize_pattern(pattern):
     yield 'path separator', '/'
 
 
-def _parse_pattern(pattern, escape_pattern=True):
+def _parse_pattern(pattern, escape_pattern=True, ignore_case=False):
     """
     Parse a string pattern and return (path_parts_re, path_parts_properties)
 
@@ -121,7 +121,9 @@ def _parse_pattern(pattern, escape_pattern=True):
             if not next_re:
                 raise ValueError('A slash-separated part is empty in %r' %
                                  pattern)
-            path_parts_re.append(re.compile('^%s$' % next_re))
+            path_parts_re.append(
+                re.compile('^%s$' % next_re,
+                           re.IGNORECASE if ignore_case else 0))
             next_re = ''
             path_parts_properties.append(tuple(properties))
             properties = []
@@ -310,13 +312,15 @@ class StructuredDirectory(object):
                  root_dir,
                  pattern,
                  file_mode=0o700,
-                 escape_pattern=True):
+                 escape_pattern=True,
+                 ignore_case=False):
         self.root_dir = unicode_(root_dir)
         self.pattern = unicode_(pattern)
         # Cache for file descriptors.
         self.cache = {}
         parts_re, parts_properties = _parse_pattern(self.pattern,
-                                                    escape_pattern)
+                                                    escape_pattern,
+                                                    ignore_case)
         self.file_mode = file_mode
         self._path_parts_re = parts_re
         self._path_parts_properties = parts_properties

--- a/python/multicorn/fsfdw/structuredfs.py
+++ b/python/multicorn/fsfdw/structuredfs.py
@@ -192,8 +192,7 @@ class Item(collections.Mapping):
         self._properties = {}
         self.content = content
         self.actual_filename = actual_filename
-        self.mtime = datetime.datetime.fromtimestamp(mtime) if mtime else None
-        self.ctime = datetime.datetime.fromtimestamp(ctime) if ctime else None
+        self.set_timestamps(mtime, ctime)
         # TODO: check for ambiguities.
         # eg. with pattern = '{a}_{b}', values {'a': '1_2', 'b': '3'} and
         # {'a': '1', 'b': '2_3'} both give the same filename.
@@ -297,6 +296,10 @@ class Item(collections.Mapping):
     def remove(self):
         os.unlink(self.full_filename)
 
+    def set_timestamps(self, mtime, ctime):
+        self.mtime = datetime.datetime.fromtimestamp(mtime) if mtime else None
+        self.ctime = datetime.datetime.fromtimestamp(ctime) if ctime else None
+
     # collections.Mapping interface:
 
     def __len__(self):
@@ -370,7 +373,7 @@ class StructuredDirectory(object):
             if match is None:
                 return None
             values.update(match.groupdict())
-        return Item(self, values)
+        return Item(self, values, actual_filename=filename)
 
     def get_items(self, **fixed_values):
         """


### PR DESCRIPTION
Highlights:
* Support regular expressions in `pattern` option
* Allow for case sensitive or insensitive pattern matches
* Expose file mtime and ctime as timestamps

This PR adds four more options to `FilesystemFdw`:
* `escape_pattern` (default: `TRUE`) 
  If TRUE, the pattern used to match files is escaped before it is
  used for regular expression matching. If FALSE, the pattern used to
  match files is used as is and it is assumed to be a valid regular
  expression.
* `ignore_case` (default: `FALSE`)
  If FALSE, the pattern used to match files is case sensitive. If
  TRUE, the pattern used to match files is case insensitive.
* `mtime_column`
  If set, defines which column will contain the file mtime.
* `ctime_column`
  If set, defines which column will contain the file ctime.

With this PR, the following example is supported:
```
> ls -R1 f
f:
taz

f/taz:
a_b.jpeg
a_b.JPEG
a-b.jpg
a_b.png
a b.PNG
```
```SQL
CREATE FOREIGN TABLE foo (
    filename VARCHAR,
    mtime TIMESTAMP,
    ctime TIMESTAMP,
    foo VARCHAR,
    bar VARCHAR,
    taz VARCHAR
) SERVER filesystem_srv OPTIONS (
    root_dir        '/f',
    pattern         '{taz}/{foo}[ _-]{bar}\.(jpe?g|png)',
    escape_pattern  'FALSE',
    ignore_case     'TRUE',
    filename_column 'filename',
    mtime_column    'mtime',
    ctime_column    'ctime');
SELECT * FROM foo;
```
```SQL
 filename |        mtime        |        ctime        | foo | bar | taz 
----------+---------------------+---------------------+-----+-----+-----
 a_b.jpeg | 2018-04-19 18:37:06 | 2018-04-20 19:20:12 | a   | b   | taz
 a_b.png  | 2018-04-19 18:37:04 | 2018-04-20 19:20:12 | a   | b   | taz
 a-b.jpg  | 2018-04-19 18:37:30 | 2018-04-20 19:20:12 | a   | b   | taz
 a_b.JPEG | 2018-04-19 18:37:09 | 2018-04-20 19:20:12 | a   | b   | taz
 a b.PNG  | 2018-04-19 18:37:15 | 2018-04-20 19:20:12 | a   | b   | taz
(5 rows)
```
Notice the regular expression used for the `pattern` option which allows for the `foo` and `bar` tokens to be separated by ` `, `_`, or `-`. Also, the file extensions can be `.jpg`, `.jpeg`, or `.png`, case insensitive.

Fix for #203