### PR TITLE
Fix for mishandling of None elements in sequence lines.

### DIFF
--- a/python/multicorn/testfdw.py
+++ b/python/multicorn/testfdw.py
@@ -15,6 +15,7 @@ class TestForeignDataWrapper(ForeignDataWrapper):
         super(TestForeignDataWrapper, self).__init__(options, columns)
         self.columns = columns
         self.test_type = options.get('test_type', None)
+        self.test_subtype = options.get('test_subtype', None)
         self.tx_hook = options.get('tx_hook', False)
         self._row_id_column = options.get('row_id_column',
                                           list(self.columns.keys())[0])
@@ -35,8 +36,11 @@ class TestForeignDataWrapper(ForeignDataWrapper):
             if self.test_type == 'sequence':
                 line = []
                 for column_name in self.columns:
-                    line.append('%s %s %s' % (column_name,
-                                              next(random_thing), index))
+                    if self.test_subtype == '1null' and len(line) == 0:
+                        line.append(None)
+                    else:
+                        line.append('%s %s %s' % (column_name,
+                                                  next(random_thing), index))
             else:
                 line = {}
                 for column_name, column in self.columns.items():

--- a/src/python.c
+++ b/src/python.c
@@ -1274,18 +1274,20 @@ pythonSequenceToTuple(PyObject *p_value,
 		if(p_object == NULL || p_object == Py_None){
 			nulls[i] = true;
 			values[i] = 0;
-			continue;
-		}
-		resetStringInfo(buffer);
-		values[i] = pyobjectToDatum(p_object, buffer,
-									cinfos[cinfo_idx]);
-		if (buffer->data == NULL)
-		{
-			nulls[i] = true;
 		}
 		else
 		{
-			nulls[i] = false;
+			resetStringInfo(buffer);
+			values[i] = pyobjectToDatum(p_object, buffer,
+										cinfos[cinfo_idx]);
+			if (buffer->data == NULL)
+			{
+				nulls[i] = true;
+			}
+			else
+			{
+				nulls[i] = false;
+			}
 		}
 		errorCheck();
 		Py_DECREF(p_object);

--- a/test-2.7/expected/multicorn_sequence_test.out
+++ b/test-2.7/expected/multicorn_sequence_test.out
@@ -330,9 +330,28 @@ NOTICE:  ['test1', 'test2']
  test1 3 19 | test2 1 19
 (40 rows)
 
+CREATE foreign table testmulticorn3 (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    test_type 'sequence',
+    test_subtype '1null'
+);
+select * from testmulticorn3 limit 1;
+NOTICE:  [('option1', 'option1'), ('test_subtype', '1null'), ('test_type', 'sequence'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  []
+NOTICE:  ['test1', 'test2']
+ test1 |   test2   
+-------+-----------
+       | test2 1 0
+(1 row)
+
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to server multicorn_srv
 drop cascades to foreign table testmulticorn
 drop cascades to foreign table testmulticorn2
+drop cascades to foreign table testmulticorn3

--- a/test-2.7/sql/multicorn_sequence_test.sql
+++ b/test-2.7/sql/multicorn_sequence_test.sql
@@ -47,5 +47,16 @@ CREATE foreign table testmulticorn2 (
 );
 
 select * from testmulticorn union all select * from testmulticorn2;
+
+CREATE foreign table testmulticorn3 (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    test_type 'sequence',
+    test_subtype '1null'
+);
+select * from testmulticorn3 limit 1;
+
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;

--- a/test-3.3/expected/multicorn_sequence_test.out
+++ b/test-3.3/expected/multicorn_sequence_test.out
@@ -330,9 +330,28 @@ NOTICE:  ['test1', 'test2']
  test1 3 19 | test2 1 19
 (40 rows)
 
+CREATE foreign table testmulticorn3 (
+    test1 character varying,
+    test2 character varying
+) server multicorn_srv options (
+    option1 'option1',
+    test_type 'sequence',
+    test_subtype '1null'
+);
+select * from testmulticorn3 limit 1;
+NOTICE:  [('option1', 'option1'), ('test_subtype', '1null'), ('test_type', 'sequence'), ('usermapping', 'test')]
+NOTICE:  [('test1', 'character varying'), ('test2', 'character varying')]
+NOTICE:  []
+NOTICE:  ['test1', 'test2']
+ test1 |   test2   
+-------+-----------
+       | test2 1 0
+(1 row)
+
 DROP USER MAPPING FOR postgres SERVER multicorn_srv;
 DROP EXTENSION multicorn cascade;
-NOTICE:  drop cascades to 3 other objects
+NOTICE:  drop cascades to 4 other objects
 DETAIL:  drop cascades to server multicorn_srv
 drop cascades to foreign table testmulticorn
 drop cascades to foreign table testmulticorn2
+drop cascades to foreign table testmulticorn3


### PR DESCRIPTION
The previous fix for #102 would emit NULL for the entire row as it
skipped incrementing the index into the Python sequence. This commit
fixes this and adds regression tests for the problem.