### PR TITLE
Fix: src/multicorn.h:18:28: fatal error

### DIFF
--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -14,7 +14,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/pg_list.h"
 
-#if PG_VERSION_NUM != 120000
+#if PG_VERSION_NUM <= 120000
 #include "nodes/relation.h"
 #endif
 #include "utils/builtins.h"


### PR DESCRIPTION
Fix compilation error for PostgreSQL 12.1:
In file included from src/errors.c:15:0:
src/multicorn.h:18:28: fatal error: nodes/relation.h: No such file or directory
 #include "nodes/relation.h"