### PR TITLE
Fix PG_VERSION_NUM for PG > 12.0

### DIFF
--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -14,7 +14,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/pg_list.h"
 
-#if PG_VERSION_NUM != 120000
+#if PG_VERSION_NUM < 120000
 #include "nodes/relation.h"
 #endif
 #include "utils/builtins.h"


### PR DESCRIPTION
Spotted by the Debian CI pipeline:
https://salsa.debian.org/postgresql/postgresql-multicorn/-/jobs/445220